### PR TITLE
💥 Add a distinction between exceptions and errors

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,27 +1,8 @@
-export interface ErrorOptions {
-  cause?: unknown;
-}
+import { Exception } from "./exceptions.js";
 
-export abstract class CustomError extends Error {
-  public constructor(name: string, message?: string, options?: ErrorOptions) {
-    super(message, options);
-
-    Object.defineProperty(this, "name", {
-      value: name,
-      enumerable: false,
-      configurable: true,
-    });
-
-    Object.setPrototypeOf(this, new.target.prototype);
-
-    if ("captureStackTrace" in Error) {
-      Error.captureStackTrace(this, new.target);
-    }
-  }
-}
-
-export class UnsafeExtractError extends CustomError {
+export class UnsafeExtractError extends Exception {
   public constructor(message: string) {
-    super("UnsafeExtractError", message);
+    super(message);
+    this.setName("UnsafeExtractError");
   }
 }

--- a/src/exceptions.ts
+++ b/src/exceptions.ts
@@ -1,0 +1,25 @@
+export interface ErrorOptions {
+  cause?: unknown;
+}
+
+export abstract class Exception extends Error {
+  public constructor(message?: string, options?: ErrorOptions) {
+    super(message, options);
+
+    this.setName(new.target.name);
+
+    Object.setPrototypeOf(this, new.target.prototype);
+
+    if ("captureStackTrace" in Error) {
+      Error.captureStackTrace(this, new.target);
+    }
+  }
+
+  protected setName(name: string): void {
+    Object.defineProperty(this, "name", {
+      value: name,
+      enumerable: false,
+      configurable: true,
+    });
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./errors.js";
+export * from "./exceptions.js";
 export * from "./option.js";

--- a/src/option.ts
+++ b/src/option.ts
@@ -1,4 +1,5 @@
 import { UnsafeExtractError } from "./errors.js";
+import { Exception } from "./exceptions.js";
 
 export type Option<A> = Some<A> | None;
 
@@ -11,9 +12,9 @@ abstract class OptionMethods {
     return this.isSome ? new Some(morphism(this.value)) : none;
   }
 
-  public unsafeExtract<A>(this: Option<A>, error: Error | string): A {
+  public unsafeExtract<A>(this: Option<A>, error: Exception | string): A {
     if (this.isSome) return this.value;
-    throw error instanceof Error ? error : new UnsafeExtractError(error);
+    throw error instanceof Exception ? error : new UnsafeExtractError(error);
   }
 }
 

--- a/tests/option.test.ts
+++ b/tests/option.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "@jest/globals";
 import fc from "fast-check";
 
 import { UnsafeExtractError } from "../src/errors.js";
+import { Exception } from "../src/exceptions.js";
 import type { None, Option, Some } from "../src/option.js";
 import { none, some } from "../src/option.js";
 
@@ -15,10 +16,11 @@ const genNone: fc.Arbitrary<None> = fc.constant(none);
 const genOption = <A>(genValue: fc.Arbitrary<A>): fc.Arbitrary<Option<A>> =>
   fc.oneof(genSome(genValue), genNone);
 
-describe("option", () => {
+describe("Option", () => {
   describe("map", () => {
     it("should preserve identity morphisms", () => {
       expect.assertions(100);
+
       fc.assert(
         fc.property(genOption(fc.anything()), (option) => {
           expect(option.map((value) => id(value))).toStrictEqual(option);
@@ -28,8 +30,9 @@ describe("option", () => {
   });
 
   describe("unsafeExtract", () => {
-    it("should extract the value from some", () => {
+    it("should extract the value from Some", () => {
       expect.assertions(100);
+
       fc.assert(
         fc.property(fc.anything(), fc.string(), (value, message) => {
           expect(some(value).unsafeExtract(message)).toStrictEqual(value);
@@ -37,21 +40,27 @@ describe("option", () => {
       );
     });
 
-    it("should throw an UnsafeExtractError for none", () => {
-      expect.assertions(100);
+    it("should throw an UnsafeExtractError for None", () => {
+      expect.assertions(200);
+
       fc.assert(
         fc.property(fc.string(), (message) => {
+          const error = new UnsafeExtractError(message);
+          expect(() => none.unsafeExtract(message)).toThrow(error);
           expect(() => none.unsafeExtract(message)).toThrow(UnsafeExtractError);
         }),
       );
     });
 
-    it("should throw the custom error for none", () => {
-      expect.assertions(100);
+    it("should throw the given exception for None", () => {
+      expect.assertions(200);
+
       fc.assert(
         fc.property(fc.string(), (message) => {
-          const error = new Error(message);
+          class SomeException extends Exception {}
+          const error = new SomeException(message);
           expect(() => none.unsafeExtract(error)).toThrow(error);
+          expect(() => none.unsafeExtract(error)).toThrow(SomeException);
         }),
       );
     });


### PR DESCRIPTION
There are several distinctions between exceptions and errors.

- An exception is a known but unexpected outcome of a risky operation. On the other hand, an error is a programming mistake.
- Exceptions need to be handled. Errors need to be fixed.
- An exception becomes an error if it's not handled. An error becomes an exception when its caught at an error boundary.

In order to distinguish between exceptions and errors, thereby making the library more robust, I renamed the `CustomError` class to `Exception`. I also changed the way we construct instances of `Exception`. Furthermore, I changed the input of `unsafeExtract`. It now expects an `Exception` instead of any error. Finally, I removed the `UnsafeExtractError` class from the list of exports because it's an error. Hence, the user shouldn't be able to catch it. If the user wants to catch the error thrown by `unsafeExtract` then they should provide a custom instance of `Exception`.