### PR TITLE
✨ Add `safeExtract` and `safeExtractFrom` methods

### DIFF
--- a/src/option.ts
+++ b/src/option.ts
@@ -12,6 +12,14 @@ abstract class OptionMethods {
     return this.isSome ? new Some(morphism(this.value)) : none;
   }
 
+  public safeExtract<A>(this: Option<A>, defaultValue: A): A {
+    return this.isSome ? this.value : defaultValue;
+  }
+
+  public safeExtractFrom<A>(this: Option<A>, getDefaultValue: () => A): A {
+    return this.isSome ? this.value : getDefaultValue();
+  }
+
   public unsafeExtract<A>(this: Option<A>, error: Exception | string): A {
     if (this.isSome) return this.value;
     throw error instanceof Exception ? error : new UnsafeExtractError(error);

--- a/tests/option.test.ts
+++ b/tests/option.test.ts
@@ -29,6 +29,58 @@ describe("Option", () => {
     });
   });
 
+  describe("safeExtract", () => {
+    it("should extract the value from Some", () => {
+      expect.assertions(100);
+
+      fc.assert(
+        fc.property(fc.anything(), fc.anything(), (value, defaultValue) => {
+          expect(some(value).safeExtract(defaultValue)).toStrictEqual(value);
+        }),
+      );
+    });
+
+    it("should return the default value for None", () => {
+      expect.assertions(100);
+
+      fc.assert(
+        fc.property(fc.anything(), (defaultValue) => {
+          expect(none.safeExtract(defaultValue)).toStrictEqual(defaultValue);
+        }),
+      );
+    });
+  });
+
+  describe("safeExtractFrom", () => {
+    it("should extract the value from Some", () => {
+      expect.assertions(100);
+
+      fc.assert(
+        fc.property(
+          fc.anything(),
+          fc.func(fc.anything()),
+          (value, getDefaultValue) => {
+            expect(some(value).safeExtractFrom(getDefaultValue)).toStrictEqual(
+              value,
+            );
+          },
+        ),
+      );
+    });
+
+    it("should return the default value for None", () => {
+      expect.assertions(100);
+
+      fc.assert(
+        fc.property(fc.func(fc.anything()), (getDefaultValue) => {
+          expect(none.safeExtractFrom(getDefaultValue)).toStrictEqual(
+            getDefaultValue(),
+          );
+        }),
+      );
+    });
+  });
+
   describe("unsafeExtract", () => {
     it("should extract the value from Some", () => {
       expect.assertions(100);


### PR DESCRIPTION
The `safeExtract` and `safeExtractFrom` methods can be used to safely extract a value from an `Option`. If the option `isNone`, then the default value will be returned. Otherwise, the option `isSome` and its `value` will be returned.