### PR TITLE
💥 Rename `safeExtractFrom` and overwrite `safeExtract`

### DIFF
--- a/src/option.ts
+++ b/src/option.ts
@@ -26,11 +26,7 @@ abstract class OptionMethods {
     return this.isSome && predicate(this.value) ? this : none;
   }
 
-  public safeExtract<A>(this: Option<A>, defaultValue: A): A {
-    return this.isSome ? this.value : defaultValue;
-  }
-
-  public safeExtractFrom<A>(this: Option<A>, getDefaultValue: () => A): A {
+  public safeExtract<A>(this: Option<A>, getDefaultValue: () => A): A {
     return this.isSome ? this.value : getDefaultValue();
   }
 

--- a/tests/option.test.ts
+++ b/tests/option.test.ts
@@ -128,33 +128,11 @@ describe("Option", () => {
       expect.assertions(100);
 
       fc.assert(
-        fc.property(fc.anything(), fc.anything(), (value, defaultValue) => {
-          expect(some(value).safeExtract(defaultValue)).toStrictEqual(value);
-        }),
-      );
-    });
-
-    it("should return the default value for None", () => {
-      expect.assertions(100);
-
-      fc.assert(
-        fc.property(fc.anything(), (defaultValue) => {
-          expect(none.safeExtract(defaultValue)).toStrictEqual(defaultValue);
-        }),
-      );
-    });
-  });
-
-  describe("safeExtractFrom", () => {
-    it("should extract the value from Some", () => {
-      expect.assertions(100);
-
-      fc.assert(
         fc.property(
           fc.anything(),
           fc.func(fc.anything()),
           (value, getDefaultValue) => {
-            expect(some(value).safeExtractFrom(getDefaultValue)).toStrictEqual(
+            expect(some(value).safeExtract(getDefaultValue)).toStrictEqual(
               value,
             );
           },
@@ -167,7 +145,7 @@ describe("Option", () => {
 
       fc.assert(
         fc.property(fc.func(fc.anything()), (getDefaultValue) => {
-          expect(none.safeExtractFrom(getDefaultValue)).toStrictEqual(
+          expect(none.safeExtract(getDefaultValue)).toStrictEqual(
             getDefaultValue(),
           );
         }),


### PR DESCRIPTION
We don't need both the `safeExtract` and `safeExtractFrom` methods. The `safeExtractFrom` method can easily do the job of `safeExtract` too. Hence, I renamed `safeExtractFrom` to `safeExtract` overwriting the old defintiion of `safeExtract`.