### PR TITLE
✨ Add the `Result` type and its data constructors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./exceptions.js";
 export * from "./option.js";
+export * from "./result.js";

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,0 +1,40 @@
+export type Result<E, A> = Success<A> | Failure<E>;
+
+abstract class ResultMethods {
+  public abstract readonly isSuccess: boolean;
+
+  public abstract readonly isFailure: boolean;
+
+  public map<E, A, B>(
+    this: Result<E, A>,
+    morphism: (value: A) => B,
+  ): Result<E, B> {
+    return this.isSuccess ? new Success(morphism(this.value)) : this;
+  }
+}
+
+class Success<out A> extends ResultMethods {
+  public override readonly isSuccess = true;
+
+  public override readonly isFailure = false;
+
+  public constructor(public readonly value: A) {
+    super();
+  }
+}
+
+class Failure<out E> extends ResultMethods {
+  public override readonly isSuccess = false;
+
+  public override readonly isFailure = true;
+
+  public constructor(public readonly error: E) {
+    super();
+  }
+}
+
+export const success = <A>(value: A): Success<A> => new Success(value);
+
+export const failure = <E>(error: E): Failure<E> => new Failure(error);
+
+export type { Success, Failure };

--- a/tests/result.test.ts
+++ b/tests/result.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "@jest/globals";
+import fc from "fast-check";
+
+import type { Failure, Result, Success } from "../src/result.js";
+import { failure, success } from "../src/result.js";
+
+const id = <A>(value: A): A => value;
+
+const genSuccess = <A>(genValue: fc.Arbitrary<A>): fc.Arbitrary<Success<A>> =>
+  genValue.map((value) => success(value));
+
+const genFailure = <E>(genError: fc.Arbitrary<E>): fc.Arbitrary<Failure<E>> =>
+  genError.map((error) => failure(error));
+
+const genResult = <E, A>(
+  genValue: fc.Arbitrary<A>,
+  genError: fc.Arbitrary<E>,
+): fc.Arbitrary<Result<E, A>> =>
+  fc.oneof(genSuccess(genValue), genFailure(genError));
+
+describe("Result", () => {
+  describe("map", () => {
+    it("should preserve identity morphisms", () => {
+      expect.assertions(100);
+
+      fc.assert(
+        fc.property(genResult(fc.anything(), fc.anything()), (result) => {
+          expect(result.map((value) => id(value))).toStrictEqual(result);
+        }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
The `Result` type is a commonly used type in functional programming. Hence, I added the `Result` type, its data constructors, the `map` method, and unit tests in this commit.