### PR TITLE
💥 Export classes instead of the data constructors

### DIFF
--- a/src/option.ts
+++ b/src/option.ts
@@ -9,21 +9,21 @@ abstract class OptionMethods {
   public abstract readonly isNone: boolean;
 
   public map<A, B>(this: Option<A>, morphism: (value: A) => B): Option<B> {
-    return this.isSome ? new Some(morphism(this.value)) : none;
+    return this.isSome ? new Some(morphism(this.value)) : None.instance;
   }
 
   public flatMap<A, B>(
     this: Option<A>,
     arrow: (value: A) => Option<B>,
   ): Option<B> {
-    return this.isSome ? arrow(this.value) : none;
+    return this.isSome ? arrow(this.value) : None.instance;
   }
 
   public filter<A>(
     this: Option<A>,
     predicate: (value: A) => boolean,
   ): Option<A> {
-    return this.isSome && predicate(this.value) ? this : none;
+    return this.isSome && predicate(this.value) ? this : None.instance;
   }
 
   public safeExtract<A>(this: Option<A>, getDefaultValue: () => A): A {
@@ -36,7 +36,7 @@ abstract class OptionMethods {
   }
 }
 
-class Some<out A> extends OptionMethods {
+export class Some<out A> extends OptionMethods {
   public override readonly isSome = true;
 
   public override readonly isNone = false;
@@ -46,14 +46,14 @@ class Some<out A> extends OptionMethods {
   }
 }
 
-class None extends OptionMethods {
+export class None extends OptionMethods {
   public override readonly isSome = false;
 
   public override readonly isNone = true;
+
+  private constructor() {
+    super();
+  }
+
+  public static readonly instance = new None();
 }
-
-export const some = <A>(value: A): Some<A> => new Some(value);
-
-export const none = new None();
-
-export type { Some, None };

--- a/src/result.ts
+++ b/src/result.ts
@@ -13,7 +13,7 @@ abstract class ResultMethods {
   }
 }
 
-class Success<out A> extends ResultMethods {
+export class Success<out A> extends ResultMethods {
   public override readonly isSuccess = true;
 
   public override readonly isFailure = false;
@@ -23,7 +23,7 @@ class Success<out A> extends ResultMethods {
   }
 }
 
-class Failure<out E> extends ResultMethods {
+export class Failure<out E> extends ResultMethods {
   public override readonly isSuccess = false;
 
   public override readonly isFailure = true;
@@ -32,9 +32,3 @@ class Failure<out E> extends ResultMethods {
     super();
   }
 }
-
-export const success = <A>(value: A): Success<A> => new Success(value);
-
-export const failure = <E>(error: E): Failure<E> => new Failure(error);
-
-export type { Success, Failure };

--- a/tests/result.test.ts
+++ b/tests/result.test.ts
@@ -1,16 +1,16 @@
 import { describe, expect, it } from "@jest/globals";
 import fc from "fast-check";
 
-import type { Failure, Result, Success } from "../src/result.js";
-import { failure, success } from "../src/result.js";
+import type { Result } from "../src/result.js";
+import { Failure, Success } from "../src/result.js";
 
 const id = <A>(value: A): A => value;
 
 const genSuccess = <A>(genValue: fc.Arbitrary<A>): fc.Arbitrary<Success<A>> =>
-  genValue.map((value) => success(value));
+  genValue.map((value) => new Success(value));
 
 const genFailure = <E>(genError: fc.Arbitrary<E>): fc.Arbitrary<Failure<E>> =>
-  genError.map((error) => failure(error));
+  genError.map((error) => new Failure(error));
 
 const genResult = <E, A>(
   genValue: fc.Arbitrary<A>,


### PR DESCRIPTION
There's no need to create data constructor functions. It just adds unnecessary indirection. Users can create instances of the class directly.