### PR TITLE
✨ Add the `toResult` method to `OptionMethods`

### DIFF
--- a/src/option.ts
+++ b/src/option.ts
@@ -1,5 +1,7 @@
 import { UnsafeExtractError } from "./errors.js";
 import { Exception } from "./exceptions.js";
+import type { Result } from "./result.js";
+import { Failure, Success } from "./result.js";
 
 export type Option<A> = Some<A> | None;
 
@@ -33,6 +35,10 @@ abstract class OptionMethods {
   public unsafeExtract<A>(this: Option<A>, error: Exception | string): A {
     if (this.isSome) return this.value;
     throw error instanceof Exception ? error : new UnsafeExtractError(error);
+  }
+
+  public toResult<E, A>(this: Option<A>, getError: () => E): Result<E, A> {
+    return this.isSome ? new Success(this.value) : new Failure(getError());
   }
 }
 

--- a/tests/option.test.ts
+++ b/tests/option.test.ts
@@ -5,6 +5,7 @@ import { UnsafeExtractError } from "../src/errors.js";
 import { Exception } from "../src/exceptions.js";
 import type { Option } from "../src/option.js";
 import { None, Some } from "../src/option.js";
+import { Failure, Success } from "../src/result.js";
 
 const id = <A>(value: A): A => value;
 
@@ -190,6 +191,36 @@ describe("Option", () => {
           expect(() => None.instance.unsafeExtract(error)).toThrow(error);
           expect(() => None.instance.unsafeExtract(error)).toThrow(
             SomeException,
+          );
+        }),
+      );
+    });
+  });
+
+  describe("toResult", () => {
+    it("should convert Some to Success", () => {
+      expect.assertions(100);
+
+      fc.assert(
+        fc.property(
+          fc.anything(),
+          fc.func(fc.anything()),
+          (value, getError) => {
+            expect(new Some(value).toResult(getError)).toStrictEqual(
+              new Success(value),
+            );
+          },
+        ),
+      );
+    });
+
+    it("should convert None to Failure", () => {
+      expect.assertions(100);
+
+      fc.assert(
+        fc.property(genNone, fc.func(fc.anything()), (none, getError) => {
+          expect(none.toResult(getError)).toStrictEqual(
+            new Failure(getError()),
           );
         }),
       );


### PR DESCRIPTION
Converting an `Option` into a `Result` is a commonly used operation.