### PR TITLE
✨ Add `[Symbol.iterator]` to `OptionMethods`

### DIFF
--- a/src/option.ts
+++ b/src/option.ts
@@ -40,6 +40,10 @@ abstract class OptionMethods {
   public toResult<E, A>(this: Option<A>, getError: () => E): Result<E, A> {
     return this.isSome ? new Success(this.value) : new Failure(getError());
   }
+
+  public *[Symbol.iterator]<A>(this: Option<A>): Generator<A, void, undefined> {
+    if (this.isSome) yield this.value;
+  }
 }
 
 export class Some<out A> extends OptionMethods {

--- a/tests/option.test.ts
+++ b/tests/option.test.ts
@@ -226,4 +226,26 @@ describe("Option", () => {
       );
     });
   });
+
+  describe("[Symbol.iterator]", () => {
+    it("should iterate over the value of Some", () => {
+      expect.assertions(100);
+
+      fc.assert(
+        fc.property(fc.anything(), (value) => {
+          expect([...new Some(value)]).toStrictEqual([value]);
+        }),
+      );
+    });
+
+    it("should not iterate over None", () => {
+      expect.assertions(100);
+
+      fc.assert(
+        fc.property(genNone, (none) => {
+          expect([...none]).toStrictEqual([]);
+        }),
+      );
+    });
+  });
 });


### PR DESCRIPTION
Iterating over the value of an `Option` is a common operation.