### PR TITLE
🚚 Rename `OptionMethods` and `ResultMethods`

### DIFF
--- a/src/option.ts
+++ b/src/option.ts
@@ -5,7 +5,7 @@ import { Failure, Success } from "./result.js";
 
 export type Option<A> = Some<A> | None;
 
-abstract class OptionMethods {
+abstract class OptionTrait {
   public abstract readonly isSome: boolean;
 
   public abstract readonly isNone: boolean;
@@ -46,7 +46,7 @@ abstract class OptionMethods {
   }
 }
 
-export class Some<out A> extends OptionMethods {
+export class Some<out A> extends OptionTrait {
   public override readonly isSome = true;
 
   public override readonly isNone = false;
@@ -56,7 +56,7 @@ export class Some<out A> extends OptionMethods {
   }
 }
 
-export class None extends OptionMethods {
+export class None extends OptionTrait {
   public override readonly isSome = false;
 
   public override readonly isNone = true;

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,6 +1,6 @@
 export type Result<E, A> = Success<A> | Failure<E>;
 
-abstract class ResultMethods {
+abstract class ResultTrait {
   public abstract readonly isSuccess: boolean;
 
   public abstract readonly isFailure: boolean;
@@ -13,7 +13,7 @@ abstract class ResultMethods {
   }
 }
 
-export class Success<out A> extends ResultMethods {
+export class Success<out A> extends ResultTrait {
   public override readonly isSuccess = true;
 
   public override readonly isFailure = false;
@@ -23,7 +23,7 @@ export class Success<out A> extends ResultMethods {
   }
 }
 
-export class Failure<out E> extends ResultMethods {
+export class Failure<out E> extends ResultTrait {
   public override readonly isSuccess = false;
 
   public override readonly isFailure = true;


### PR DESCRIPTION
The `OptionMethods` and `ResultMethods` classes contain more than just methods. It's more accurate to call them `OptionTrait` and `ResultTrait` respectively.