### PR TITLE
✨ Add `Expression` type and the `evaluate` function

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,6 +27,9 @@
       "node": true
     }
   },
+  "rules": {
+    "unicorn/no-array-callback-reference": "off"
+  },
   "overrides": [
     {
       "files": ["tests/**"],

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -1,0 +1,9 @@
+export type Thunk<A> = () => A;
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type NonFunction<A> = A extends Function ? never : A;
+
+export type Expression<A> = Thunk<A> | NonFunction<A>;
+
+export const evaluate = <A>(expression: Expression<A>): A =>
+  typeof expression === "function" ? (expression as Thunk<A>)() : expression;

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -5,5 +5,11 @@ export type NonFunction<A> = A extends Function ? never : A;
 
 export type Expression<A> = Thunk<A> | NonFunction<A>;
 
+export const isThunk = <A>(expression: Expression<A>): expression is Thunk<A> =>
+  typeof expression === "function";
+
+export const isNonFunction = <A>(value: A): value is NonFunction<A> =>
+  typeof value !== "function";
+
 export const evaluate = <A>(expression: Expression<A>): A =>
-  typeof expression === "function" ? (expression as Thunk<A>)() : expression;
+  isThunk(expression) ? expression() : expression;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./exceptions.js";
+export * from "./expression.js";
 export * from "./option.js";
 export * from "./result.js";

--- a/tests/arbitraries.ts
+++ b/tests/arbitraries.ts
@@ -1,0 +1,38 @@
+import fc from "fast-check";
+
+import type { Expression, NonFunction, Thunk } from "../src/expression.js";
+import { isNonFunction } from "../src/expression.js";
+import type { Option } from "../src/option.js";
+import { None, Some } from "../src/option.js";
+import type { Result } from "../src/result.js";
+import { Failure, Success } from "../src/result.js";
+
+export const thunk = <A>(a: fc.Arbitrary<A>): fc.Arbitrary<Thunk<A>> =>
+  a.map((value) => () => value);
+
+export const nonFunction = <A>(
+  a: fc.Arbitrary<A>,
+): fc.Arbitrary<NonFunction<A>> => a.filter(isNonFunction);
+
+export const expression = <A>(
+  a: fc.Arbitrary<A>,
+): fc.Arbitrary<Expression<A>> => fc.oneof(thunk(a), nonFunction(a));
+
+export const some = <A>(a: fc.Arbitrary<A>): fc.Arbitrary<Some<A>> =>
+  a.map((value) => new Some(value));
+
+export const none: fc.Arbitrary<None> = fc.constant(None.instance);
+
+export const option = <A>(a: fc.Arbitrary<A>): fc.Arbitrary<Option<A>> =>
+  fc.oneof(some(a), none);
+
+export const success = <A>(a: fc.Arbitrary<A>): fc.Arbitrary<Success<A>> =>
+  a.map((value) => new Success(value));
+
+export const failure = <E>(b: fc.Arbitrary<E>): fc.Arbitrary<Failure<E>> =>
+  b.map((error) => new Failure(error));
+
+export const result = <E, A>(
+  a: fc.Arbitrary<A>,
+  b: fc.Arbitrary<E>,
+): fc.Arbitrary<Result<E, A>> => fc.oneof(success(a), failure(b));

--- a/tests/option.test.ts
+++ b/tests/option.test.ts
@@ -134,8 +134,8 @@ describe("Option", () => {
         fc.property(
           fc.anything(),
           fc.func(fc.anything()),
-          (value, getDefaultValue) => {
-            expect(new Some(value).safeExtract(getDefaultValue)).toStrictEqual(
+          (value, defaultValue) => {
+            expect(new Some(value).safeExtract(defaultValue)).toStrictEqual(
               value,
             );
           },
@@ -147,9 +147,9 @@ describe("Option", () => {
       expect.assertions(100);
 
       fc.assert(
-        fc.property(fc.func(fc.anything()), (getDefaultValue) => {
-          expect(None.instance.safeExtract(getDefaultValue)).toStrictEqual(
-            getDefaultValue(),
+        fc.property(fc.func(fc.anything()), (defaultValue) => {
+          expect(None.instance.safeExtract(defaultValue)).toStrictEqual(
+            defaultValue(),
           );
         }),
       );
@@ -202,15 +202,11 @@ describe("Option", () => {
       expect.assertions(100);
 
       fc.assert(
-        fc.property(
-          fc.anything(),
-          fc.func(fc.anything()),
-          (value, getError) => {
-            expect(new Some(value).toResult(getError)).toStrictEqual(
-              new Success(value),
-            );
-          },
-        ),
+        fc.property(fc.anything(), fc.func(fc.anything()), (value, error) => {
+          expect(new Some(value).toResult(error)).toStrictEqual(
+            new Success(value),
+          );
+        }),
       );
     });
 
@@ -218,10 +214,8 @@ describe("Option", () => {
       expect.assertions(100);
 
       fc.assert(
-        fc.property(genNone, fc.func(fc.anything()), (none, getError) => {
-          expect(none.toResult(getError)).toStrictEqual(
-            new Failure(getError()),
-          );
+        fc.property(genNone, fc.func(fc.anything()), (none, error) => {
+          expect(none.toResult(error)).toStrictEqual(new Failure(error()));
         }),
       );
     });

--- a/tests/result.test.ts
+++ b/tests/result.test.ts
@@ -2,32 +2,21 @@ import { describe, expect, it } from "@jest/globals";
 import fc from "fast-check";
 
 import type { Result } from "../src/result.js";
-import { Failure, Success } from "../src/result.js";
+
+import { result } from "./arbitraries.js";
 
 const id = <A>(value: A): A => value;
 
-const genSuccess = <A>(genValue: fc.Arbitrary<A>): fc.Arbitrary<Success<A>> =>
-  genValue.map((value) => new Success(value));
-
-const genFailure = <E>(genError: fc.Arbitrary<E>): fc.Arbitrary<Failure<E>> =>
-  genError.map((error) => new Failure(error));
-
-const genResult = <E, A>(
-  genValue: fc.Arbitrary<A>,
-  genError: fc.Arbitrary<E>,
-): fc.Arbitrary<Result<E, A>> =>
-  fc.oneof(genSuccess(genValue), genFailure(genError));
+const mapIdentity = <E, A>(u: Result<E, A>): void => {
+  expect(u.map(id)).toStrictEqual(u);
+};
 
 describe("Result", () => {
   describe("map", () => {
     it("should preserve identity morphisms", () => {
       expect.assertions(100);
 
-      fc.assert(
-        fc.property(genResult(fc.anything(), fc.anything()), (result) => {
-          expect(result.map((value) => id(value))).toStrictEqual(result);
-        }),
-      );
+      fc.assert(fc.property(result(fc.anything(), fc.anything()), mapIdentity));
     });
   });
 });


### PR DESCRIPTION
The `Expression` type is a reification of an unevaluated expression, i.e. a thunk, or a non-function value. The value must be a non-function because otherwise the `Expression` type wouldn't be a disjoint union. The evaluate function return the value of a given expression. It will evaluate and return the result of a thunk. On the other hand, it will directly return non-function values.

The `Expression` type provides a very convenient way to create type-safe functions whose inputs are optionally lazy. The caller of the function can decide whether they want to provide a strict input or a lazy input. They can also do so for each argument separately. It's also useful for API designers because they don't have to create separate functions for strict and lazy inputs. It also makes it easier to test the functions.
