### PR TITLE
💥 Make the `Option` and `Result` constructors lazy

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,6 +28,7 @@
     }
   },
   "rules": {
+    "@typescript-eslint/unbound-method": ["error", { "ignoreStatic": true }],
     "unicorn/no-array-callback-reference": "off"
   },
   "overrides": [

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -13,3 +13,30 @@ export const isNonFunction = <A>(value: A): value is NonFunction<A> =>
 
 export const evaluate = <A>(expression: Expression<A>): A =>
   isThunk(expression) ? expression() : expression;
+
+export const fromValue = <A>(value: A): Expression<A> =>
+  isNonFunction(value) ? value : () => value;
+
+export const define = <T extends Record<K, A>, K extends PropertyKey, A>(
+  object: T,
+  property: K,
+  expression: Expression<A>,
+): void => {
+  if (isThunk(expression)) {
+    Object.defineProperty(object, property, {
+      get: (): A => {
+        const value = evaluate(expression);
+        Object.defineProperty(object, property, { value });
+        return value;
+      },
+      enumerable: true,
+      configurable: true,
+    });
+  } else {
+    Object.defineProperty(object, property, {
+      value: expression,
+      enumerable: true,
+      configurable: true,
+    });
+  }
+};

--- a/src/option.ts
+++ b/src/option.ts
@@ -1,7 +1,7 @@
 import { UnsafeExtractError } from "./errors.js";
 import { Exception } from "./exceptions.js";
 import type { Expression } from "./expression.js";
-import { evaluate } from "./expression.js";
+import { define, evaluate, fromValue } from "./expression.js";
 import type { Result } from "./result.js";
 import { Failure, Success } from "./result.js";
 
@@ -13,7 +13,7 @@ abstract class OptionTrait {
   public abstract readonly isNone: boolean;
 
   public map<A, B>(this: Option<A>, morphism: (value: A) => B): Option<B> {
-    return this.isSome ? new Some(morphism(this.value)) : None.instance;
+    return this.isSome ? Some.of(morphism(this.value)) : None.instance;
   }
 
   public flatMap<A, B>(
@@ -44,7 +44,7 @@ abstract class OptionTrait {
   }
 
   public toResult<E, A>(this: Option<A>, error: Expression<E>): Result<E, A> {
-    return this.isSome ? new Success(this.value) : new Failure(evaluate(error));
+    return this.isSome ? Success.of(this.value) : new Failure(error);
   }
 
   public *[Symbol.iterator]<A>(this: Option<A>): Generator<A, void, undefined> {
@@ -57,8 +57,15 @@ export class Some<out A> extends OptionTrait {
 
   public override readonly isNone = false;
 
-  public constructor(public readonly value: A) {
+  public readonly value!: A;
+
+  public constructor(value: Expression<A>) {
     super();
+    define(this, "value", value);
+  }
+
+  public static of<A>(value: A): Some<A> {
+    return new Some(fromValue(value));
   }
 }
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,3 +1,6 @@
+import type { Expression } from "./expression.js";
+import { define, fromValue } from "./expression.js";
+
 export type Result<E, A> = Success<A> | Failure<E>;
 
 abstract class ResultTrait {
@@ -9,7 +12,14 @@ abstract class ResultTrait {
     this: Result<E, A>,
     morphism: (value: A) => B,
   ): Result<E, B> {
-    return this.isSuccess ? new Success(morphism(this.value)) : this;
+    return this.isSuccess ? Success.of(morphism(this.value)) : this;
+  }
+
+  public mapFailure<E, F, A>(
+    this: Result<E, A>,
+    morphism: (error: E) => F,
+  ): Result<F, A> {
+    return this.isFailure ? Failure.of(morphism(this.error)) : this;
   }
 }
 
@@ -18,8 +28,15 @@ export class Success<out A> extends ResultTrait {
 
   public override readonly isFailure = false;
 
-  public constructor(public readonly value: A) {
+  public readonly value!: A;
+
+  public constructor(value: Expression<A>) {
     super();
+    define(this, "value", value);
+  }
+
+  public static of<A>(value: A): Success<A> {
+    return new Success(fromValue(value));
   }
 }
 
@@ -28,7 +45,14 @@ export class Failure<out E> extends ResultTrait {
 
   public override readonly isFailure = true;
 
-  public constructor(public readonly error: E) {
+  public readonly error!: E;
+
+  public constructor(error: Expression<E>) {
     super();
+    define(this, "error", error);
+  }
+
+  public static of<E>(error: E): Failure<E> {
+    return new Failure(fromValue(error));
   }
 }

--- a/tests/arbitraries.ts
+++ b/tests/arbitraries.ts
@@ -19,7 +19,7 @@ export const expression = <A>(
 ): fc.Arbitrary<Expression<A>> => fc.oneof(thunk(a), nonFunction(a));
 
 export const some = <A>(a: fc.Arbitrary<A>): fc.Arbitrary<Some<A>> =>
-  a.map((value) => new Some(value));
+  a.map(Some.of);
 
 export const none: fc.Arbitrary<None> = fc.constant(None.instance);
 
@@ -27,10 +27,10 @@ export const option = <A>(a: fc.Arbitrary<A>): fc.Arbitrary<Option<A>> =>
   fc.oneof(some(a), none);
 
 export const success = <A>(a: fc.Arbitrary<A>): fc.Arbitrary<Success<A>> =>
-  a.map((value) => new Success(value));
+  a.map(Success.of);
 
 export const failure = <E>(b: fc.Arbitrary<E>): fc.Arbitrary<Failure<E>> =>
-  b.map((error) => new Failure(error));
+  b.map(Failure.of);
 
 export const result = <E, A>(
   a: fc.Arbitrary<A>,

--- a/tests/expression.test.ts
+++ b/tests/expression.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "@jest/globals";
+import fc from "fast-check";
+
+import { evaluate, fromValue } from "../src/expression.js";
+
+const evaluateFromValueIdentity = <A>(value: A): void => {
+  expect(evaluate(fromValue(value))).toStrictEqual(value);
+};
+
+describe("Expression", () => {
+  describe("evaluateFromValue", () => {
+    it("should behave like identity", () => {
+      expect.assertions(100);
+
+      fc.assert(
+        fc.property(
+          fc.oneof(fc.anything(), fc.func(fc.anything())),
+          evaluateFromValueIdentity,
+        ),
+      );
+    });
+  });
+});

--- a/tests/option.test.ts
+++ b/tests/option.test.ts
@@ -17,11 +17,11 @@ const mapIdentity = <A>(u: Option<A>): void => {
 };
 
 const flatMapLeftIdentity = <A, B>(a: A, k: (a: A) => Option<B>): void => {
-  expect(new Some(a).flatMap(k)).toStrictEqual(k(a));
+  expect(Some.of(a).flatMap(k)).toStrictEqual(k(a));
 };
 
 const flatMapRightIdentity = <A>(m: Option<A>): void => {
-  expect(m.flatMap((a) => new Some(a))).toStrictEqual(m);
+  expect(m.flatMap(Some.of)).toStrictEqual(m);
 };
 
 const flatMapAssociativity = <A, B, C>(
@@ -51,7 +51,7 @@ const filterAnnihilation = <A>(m: Option<A>): void => {
 };
 
 const safeExtractSome = <A>(a: A, x: Expression<A>): void => {
-  expect(new Some(a).safeExtract(x)).toStrictEqual(a);
+  expect(Some.of(a).safeExtract(x)).toStrictEqual(a);
 };
 
 const safeExtractNone = <A>(x: Expression<A>): void => {
@@ -59,7 +59,7 @@ const safeExtractNone = <A>(x: Expression<A>): void => {
 };
 
 const unsafeExtractSome = <A>(a: A, x: Expression<string>): void => {
-  expect(new Some(a).unsafeExtract(x)).toStrictEqual(a);
+  expect(Some.of(a).unsafeExtract(x)).toStrictEqual(a);
 };
 
 const unsafeExtractError = (x: Expression<string>): void => {
@@ -76,15 +76,15 @@ const unsafeExtractException = (x: Expression<string>): void => {
 };
 
 const toResultSuccess = <E, A>(a: A, x: Expression<E>): void => {
-  expect(new Some(a).toResult(x)).toStrictEqual(new Success(a));
+  expect(Some.of(a).toResult(x)).toStrictEqual(Success.of(a));
 };
 
 const toResultFailure = <E>(m: None, x: Expression<E>): void => {
-  expect(m.toResult(x)).toStrictEqual(new Failure(evaluate(x)));
+  expect(m.toResult(x)).toStrictEqual(new Failure(x));
 };
 
 const iterateSome = <A>(a: A): void => {
-  expect([...new Some(a)]).toStrictEqual([a]);
+  expect([...Some.of(a)]).toStrictEqual([a]);
 };
 
 const iterateNone = (m: None): void => {

--- a/tests/result.test.ts
+++ b/tests/result.test.ts
@@ -11,12 +11,26 @@ const mapIdentity = <E, A>(u: Result<E, A>): void => {
   expect(u.map(id)).toStrictEqual(u);
 };
 
+const mapFailureIdentity = <E, A>(u: Result<E, A>): void => {
+  expect(u.mapFailure(id)).toStrictEqual(u);
+};
+
 describe("Result", () => {
   describe("map", () => {
     it("should preserve identity morphisms", () => {
       expect.assertions(100);
 
       fc.assert(fc.property(result(fc.anything(), fc.anything()), mapIdentity));
+    });
+  });
+
+  describe("mapFailure", () => {
+    it("should preserve identity morphisms", () => {
+      expect.assertions(100);
+
+      fc.assert(
+        fc.property(result(fc.anything(), fc.anything()), mapFailureIdentity),
+      );
     });
   });
 });


### PR DESCRIPTION
I made the `Some`, `Success`, and `Failure` constructors lazy by updating them to accept expressions. This is a breaking change because the constructors can't accept non-thunk function values anymore. Hence, I also created `Some.of`, `Success.of`, and `Failure.of` static methods which can be used for the old behavior. This is great because we no longer need to use the `new` keyword and we can pass these static methods around like regular functions. I also updated the tests and even added a few new tests.
