### PR TITLE
💥 Add a new `Thunk` class and remove `NonFunction`

### DIFF
--- a/src/exceptions.ts
+++ b/src/exceptions.ts
@@ -1,3 +1,5 @@
+import { defineValue } from "./expression.js";
+
 export interface ErrorOptions {
   cause?: unknown;
 }
@@ -16,10 +18,6 @@ export abstract class Exception extends Error {
   }
 
   protected setName(name: string): void {
-    Object.defineProperty(this, "name", {
-      value: name,
-      enumerable: false,
-      configurable: true,
-    });
+    defineValue(this, "name", name, { enumerable: false });
   }
 }

--- a/src/option.ts
+++ b/src/option.ts
@@ -74,7 +74,7 @@ export class None extends OptionTrait {
 
   public override readonly isNone = true;
 
-  private constructor() {
+  public constructor() {
     super();
   }
 

--- a/tests/arbitraries.ts
+++ b/tests/arbitraries.ts
@@ -1,22 +1,21 @@
 import fc from "fast-check";
 
-import type { Expression, NonFunction, Thunk } from "../src/expression.js";
-import { isNonFunction } from "../src/expression.js";
+import type { Expression, NonThunk } from "../src/expression.js";
+import { Thunk, isNonThunk } from "../src/expression.js";
 import type { Option } from "../src/option.js";
 import { None, Some } from "../src/option.js";
 import type { Result } from "../src/result.js";
 import { Failure, Success } from "../src/result.js";
 
 export const thunk = <A>(a: fc.Arbitrary<A>): fc.Arbitrary<Thunk<A>> =>
-  a.map((value) => () => value);
+  a.map((value) => new Thunk(() => value));
 
-export const nonFunction = <A>(
-  a: fc.Arbitrary<A>,
-): fc.Arbitrary<NonFunction<A>> => a.filter(isNonFunction);
+export const nonThunk = <A>(a: fc.Arbitrary<A>): fc.Arbitrary<NonThunk<A>> =>
+  a.filter(isNonThunk);
 
 export const expression = <A>(
   a: fc.Arbitrary<A>,
-): fc.Arbitrary<Expression<A>> => fc.oneof(thunk(a), nonFunction(a));
+): fc.Arbitrary<Expression<A>> => fc.oneof(thunk(a), nonThunk(a));
 
 export const some = <A>(a: fc.Arbitrary<A>): fc.Arbitrary<Some<A>> =>
   a.map(Some.of);

--- a/tests/expression.test.ts
+++ b/tests/expression.test.ts
@@ -1,22 +1,43 @@
 import { describe, expect, it } from "@jest/globals";
 import fc from "fast-check";
 
-import { evaluate, fromValue } from "../src/expression.js";
+import { defineValue, evaluate, fromValue } from "../src/expression.js";
+
+import { expression } from "./arbitraries.js";
+
+class Identity<out A> {
+  public readonly value!: A;
+
+  public constructor(value: A) {
+    defineValue(this, "value", value);
+  }
+}
+
+const defineValueIdentity = <A>(value: A): void => {
+  expect(
+    Object.getOwnPropertyDescriptor(new Identity(value), "value"),
+  ).toStrictEqual(Object.getOwnPropertyDescriptor({ value }, "value"));
+};
 
 const evaluateFromValueIdentity = <A>(value: A): void => {
   expect(evaluate(fromValue(value))).toStrictEqual(value);
 };
 
 describe("Expression", () => {
+  describe("defineValue", () => {
+    it("should behave like identity", () => {
+      expect.assertions(100);
+
+      fc.assert(fc.property(fc.anything(), defineValueIdentity));
+    });
+  });
+
   describe("evaluateFromValue", () => {
     it("should behave like identity", () => {
       expect.assertions(100);
 
       fc.assert(
-        fc.property(
-          fc.oneof(fc.anything(), fc.func(fc.anything())),
-          evaluateFromValueIdentity,
-        ),
+        fc.property(expression(fc.anything()), evaluateFromValueIdentity),
       );
     });
   });


### PR DESCRIPTION
Instead of tagging normal values as strict, it's better to tag thunks. Hence, I created a new `Thunk` class. This is a breaking change because we changed the representation of thunks.
