### PR TITLE
Feature/miscellaneous

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./exceptions.js";
+export * from "./miscellaneous.js";
 export * from "./option.js";
 export * from "./result.js";

--- a/src/miscellaneous.ts
+++ b/src/miscellaneous.ts
@@ -1,0 +1,1 @@
+export const id = <A>(value: A): A => value;

--- a/src/option.ts
+++ b/src/option.ts
@@ -61,9 +61,5 @@ export class None extends OptionTrait {
 
   public override readonly isNone = true;
 
-  public constructor() {
-    super();
-  }
-
   public static readonly instance = new None();
 }

--- a/src/option.ts
+++ b/src/option.ts
@@ -1,7 +1,7 @@
 import { UnsafeExtractError } from "./errors.js";
 import { Exception } from "./exceptions.js";
 import type { Result } from "./result.js";
-import { Failure, Success } from "./result.js";
+import { Fail, Okay } from "./result.js";
 
 export type Option<A> = Some<A> | None;
 
@@ -37,8 +37,8 @@ abstract class OptionTrait {
     throw error instanceof Exception ? error : new UnsafeExtractError(error);
   }
 
-  public toResult<E, A>(this: Option<A>, error: E): Result<E, A> {
-    return this.isSome ? new Success(this.value) : new Failure(error);
+  public toResult<E, A>(this: Option<A>, defaultValue: E): Result<E, A> {
+    return this.isSome ? new Okay(this.value) : new Fail(defaultValue);
   }
 
   public *[Symbol.iterator]<A>(this: Option<A>): Generator<A, void, undefined> {

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,41 +1,41 @@
-export type Result<E, A> = Success<A> | Failure<E>;
+export type Result<E, A> = Okay<A> | Fail<E>;
 
 abstract class ResultTrait {
-  public abstract readonly isSuccess: boolean;
+  public abstract readonly isOkay: boolean;
 
-  public abstract readonly isFailure: boolean;
+  public abstract readonly isFail: boolean;
 
-  public map<E, A, B>(
+  public mapOkay<E, A, B>(
     this: Result<E, A>,
     morphism: (value: A) => B,
   ): Result<E, B> {
-    return this.isSuccess ? new Success(morphism(this.value)) : this;
+    return this.isOkay ? new Okay(morphism(this.value)) : this;
   }
 
-  public mapFailure<E, F, A>(
+  public mapFail<E, F, A>(
     this: Result<E, A>,
-    morphism: (error: E) => F,
+    morphism: (value: E) => F,
   ): Result<F, A> {
-    return this.isFailure ? new Failure(morphism(this.error)) : this;
+    return this.isFail ? new Fail(morphism(this.value)) : this;
   }
 }
 
-export class Success<out A> extends ResultTrait {
-  public override readonly isSuccess = true;
+export class Okay<out A> extends ResultTrait {
+  public override readonly isOkay = true;
 
-  public override readonly isFailure = false;
+  public override readonly isFail = false;
 
   public constructor(public readonly value: A) {
     super();
   }
 }
 
-export class Failure<out E> extends ResultTrait {
-  public override readonly isSuccess = false;
+export class Fail<out E> extends ResultTrait {
+  public override readonly isOkay = false;
 
-  public override readonly isFailure = true;
+  public override readonly isFail = true;
 
-  public constructor(public readonly error: E) {
+  public constructor(public readonly value: E) {
     super();
   }
 }

--- a/tests/arbitraries.ts
+++ b/tests/arbitraries.ts
@@ -3,7 +3,7 @@ import fc from "fast-check";
 import type { Option } from "../src/option.js";
 import { None, Some } from "../src/option.js";
 import type { Result } from "../src/result.js";
-import { Failure, Success } from "../src/result.js";
+import { Fail, Okay } from "../src/result.js";
 
 export const some = <A>(a: fc.Arbitrary<A>): fc.Arbitrary<Some<A>> =>
   a.map((value) => new Some(value));
@@ -13,13 +13,13 @@ export const none: fc.Arbitrary<None> = fc.constant(None.instance);
 export const option = <A>(a: fc.Arbitrary<A>): fc.Arbitrary<Option<A>> =>
   fc.oneof(some(a), none);
 
-export const success = <A>(a: fc.Arbitrary<A>): fc.Arbitrary<Success<A>> =>
-  a.map((value) => new Success(value));
+export const okay = <A>(a: fc.Arbitrary<A>): fc.Arbitrary<Okay<A>> =>
+  a.map((value) => new Okay(value));
 
-export const failure = <E>(b: fc.Arbitrary<E>): fc.Arbitrary<Failure<E>> =>
-  b.map((value) => new Failure(value));
+export const fail = <E>(b: fc.Arbitrary<E>): fc.Arbitrary<Fail<E>> =>
+  b.map((value) => new Fail(value));
 
 export const result = <E, A>(
   a: fc.Arbitrary<A>,
   b: fc.Arbitrary<E>,
-): fc.Arbitrary<Result<E, A>> => fc.oneof(success(a), failure(b));
+): fc.Arbitrary<Result<E, A>> => fc.oneof(okay(a), fail(b));

--- a/tests/option.test.ts
+++ b/tests/option.test.ts
@@ -3,13 +3,12 @@ import fc from "fast-check";
 
 import { UnsafeExtractError } from "../src/errors.js";
 import { Exception } from "../src/exceptions.js";
+import { id } from "../src/miscellaneous.js";
 import type { Option } from "../src/option.js";
 import { None, Some } from "../src/option.js";
 import { Failure, Success } from "../src/result.js";
 
 import { none, option } from "./arbitraries.js";
-
-const id = <A>(value: A): A => value;
 
 const mapIdentity = <A>(u: Option<A>): void => {
   expect(u.map(id)).toStrictEqual(u);

--- a/tests/option.test.ts
+++ b/tests/option.test.ts
@@ -6,7 +6,7 @@ import { Exception } from "../src/exceptions.js";
 import { id } from "../src/miscellaneous.js";
 import type { Option } from "../src/option.js";
 import { None, Some } from "../src/option.js";
-import { Failure, Success } from "../src/result.js";
+import { Fail, Okay } from "../src/result.js";
 
 import { none, option } from "./arbitraries.js";
 
@@ -74,11 +74,11 @@ const unsafeExtractException = (x: string): void => {
 };
 
 const toResultSuccess = <E, A>(a: A, x: E): void => {
-  expect(new Some(a).toResult(x)).toStrictEqual(new Success(a));
+  expect(new Some(a).toResult(x)).toStrictEqual(new Okay(a));
 };
 
 const toResultFailure = <E>(m: None, x: E): void => {
-  expect(m.toResult(x)).toStrictEqual(new Failure(x));
+  expect(m.toResult(x)).toStrictEqual(new Fail(x));
 };
 
 const iterateSome = <A>(a: A): void => {

--- a/tests/result.test.ts
+++ b/tests/result.test.ts
@@ -6,29 +6,31 @@ import type { Result } from "../src/result.js";
 
 import { result } from "./arbitraries.js";
 
-const mapIdentity = <E, A>(u: Result<E, A>): void => {
-  expect(u.map(id)).toStrictEqual(u);
+const mapOkayIdentity = <E, A>(u: Result<E, A>): void => {
+  expect(u.mapOkay(id)).toStrictEqual(u);
 };
 
-const mapFailureIdentity = <E, A>(u: Result<E, A>): void => {
-  expect(u.mapFailure(id)).toStrictEqual(u);
+const mapFailIdentity = <E, A>(u: Result<E, A>): void => {
+  expect(u.mapFail(id)).toStrictEqual(u);
 };
 
 describe("Result", () => {
-  describe("map", () => {
-    it("should preserve identity morphisms", () => {
-      expect.assertions(100);
-
-      fc.assert(fc.property(result(fc.anything(), fc.anything()), mapIdentity));
-    });
-  });
-
-  describe("mapFailure", () => {
+  describe("mapOkay", () => {
     it("should preserve identity morphisms", () => {
       expect.assertions(100);
 
       fc.assert(
-        fc.property(result(fc.anything(), fc.anything()), mapFailureIdentity),
+        fc.property(result(fc.anything(), fc.anything()), mapOkayIdentity),
+      );
+    });
+  });
+
+  describe("mapFail", () => {
+    it("should preserve identity morphisms", () => {
+      expect.assertions(100);
+
+      fc.assert(
+        fc.property(result(fc.anything(), fc.anything()), mapFailIdentity),
       );
     });
   });

--- a/tests/result.test.ts
+++ b/tests/result.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, it } from "@jest/globals";
 import fc from "fast-check";
 
+import { id } from "../src/miscellaneous.js";
 import type { Result } from "../src/result.js";
 
 import { result } from "./arbitraries.js";
-
-const id = <A>(value: A): A => value;
 
 const mapIdentity = <E, A>(u: Result<E, A>): void => {
   expect(u.map(id)).toStrictEqual(u);


### PR DESCRIPTION
**🔥 Remove the `constructor` from the `None` class**

The `constructor` of the `None` class doesn't do anything. Hence, we can simply inherit the super class `constructor`.

**✨ Add an `id` function and use it in the tests**

We use the `id` function in both `option.test.ts` and `result.test.ts`. Since it's a commonly used function, it makes sense to export it from our library. Hence, I moved it to `src` and updated the test files to import it from `src/miscellaneous.js`.

**💥 Rename `Result` constructors to `Okay` and `Fail`**

The `Result` constructor names `Success` and `Failure` are too long. Hence, I renamed the constructors to `Okay` and `Fail`. They are four letters long, just like `Some` and `None`. And `Result` is six letters long, just like `Option`. I also renamed `error` to `value` so that you can access the `value` of `Result` without checking whether it `isOkay` or `isFail`. Finally, I renamed `map` to `mapOkay` for consistency. Since TypeScript doesn't have higher kinded types, it doesn't matter whether or not we name the method `map`. It's more descriptive to use the name `mapOkay`.
