### PR TITLE
✨ Add more methods to the `OptionTrait` class

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,7 +29,8 @@
   },
   "rules": {
     "@typescript-eslint/unbound-method": ["error", { "ignoreStatic": true }],
-    "unicorn/no-array-callback-reference": "off"
+    "unicorn/no-array-callback-reference": "off",
+    "unicorn/no-array-method-this-argument": "off"
   },
   "overrides": [
     {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./exceptions.js";
 export * from "./miscellaneous.js";
 export * from "./option.js";
+export * from "./pair.js";
 export * from "./result.js";

--- a/src/option.ts
+++ b/src/option.ts
@@ -28,6 +28,20 @@ abstract class OptionTrait {
     return this.isSome && predicate(this.value) ? this : None.instance;
   }
 
+  public isSomeAnd<A>(
+    this: Option<A>,
+    predicate: (value: A) => boolean,
+  ): boolean {
+    return this.isSome && predicate(this.value);
+  }
+
+  public isNoneOr<A>(
+    this: Option<A>,
+    predicate: (value: A) => boolean,
+  ): boolean {
+    return this.isNone || predicate(this.value);
+  }
+
   public safeExtract<A>(this: Option<A>, defaultValue: A): A {
     return this.isSome ? this.value : defaultValue;
   }

--- a/src/option.ts
+++ b/src/option.ts
@@ -68,6 +68,10 @@ export class Some<out A> extends OptionTrait {
   public constructor(public readonly value: A) {
     super();
   }
+
+  public static of<A>(value: A): Some<A> {
+    return new Some(value);
+  }
 }
 
 export class None extends OptionTrait {

--- a/src/option.ts
+++ b/src/option.ts
@@ -1,5 +1,6 @@
 import { UnsafeExtractError } from "./errors.js";
 import { Exception } from "./exceptions.js";
+import { Pair } from "./pair.js";
 import type { Result } from "./result.js";
 import { Fail, Okay } from "./result.js";
 
@@ -14,11 +15,37 @@ abstract class OptionTrait {
     return this.isSome ? new Some(morphism(this.value)) : None.instance;
   }
 
+  public replace<A, B>(this: Option<A>, value: B): Option<B> {
+    return this.isSome ? new Some(value) : None.instance;
+  }
+
+  public and<A, B>(this: Option<A>, that: Option<B>): Option<Pair<A, B>> {
+    return this.isSome && that.isSome
+      ? new Some(new Pair(this.value, that.value))
+      : None.instance;
+  }
+
+  public andThen<A, B>(this: Option<A>, that: Option<B>): Option<B> {
+    return this.isSome && that.isSome ? that : None.instance;
+  }
+
+  public andWith<A, B>(this: Option<A>, that: Option<B>): Option<A> {
+    return this.isSome && that.isSome ? this : None.instance;
+  }
+
+  public or<A>(this: Option<A>, that: Option<A>): Option<A> {
+    return this.isSome ? this : that;
+  }
+
   public flatMap<A, B>(
     this: Option<A>,
     arrow: (value: A) => Option<B>,
   ): Option<B> {
     return this.isSome ? arrow(this.value) : None.instance;
+  }
+
+  public flatten<A>(this: Option<Option<A>>): Option<A> {
+    return this.isSome ? this.value : None.instance;
   }
 
   public filter<A>(
@@ -40,6 +67,34 @@ abstract class OptionTrait {
     predicate: (value: A) => boolean,
   ): boolean {
     return this.isNone || predicate(this.value);
+  }
+
+  public unzipWith<A, B, C>(
+    this: Option<A>,
+    unzip: (value: A) => Pair<B, C>,
+  ): Pair<Option<B>, Option<C>> {
+    return this.isNone
+      ? Pair.of(None.instance)
+      : unzip(this.value).map(Some.of, Some.of);
+  }
+
+  public unzip<A, B>(this: Option<Pair<A, B>>): Pair<Option<A>, Option<B>> {
+    return this.isNone
+      ? Pair.of(None.instance)
+      : this.value.map(Some.of, Some.of);
+  }
+
+  public transposeMap<A, E, B>(
+    this: Option<A>,
+    transpose: (value: A) => Result<E, B>,
+  ): Result<E, Option<B>> {
+    return this.isNone
+      ? new Okay(None.instance)
+      : transpose(this.value).mapOkay(Some.of);
+  }
+
+  public transpose<E, A>(this: Option<Result<E, A>>): Result<E, Option<A>> {
+    return this.isNone ? new Okay(None.instance) : this.value.mapOkay(Some.of);
   }
 
   public safeExtract<A>(this: Option<A>, defaultValue: A): A {

--- a/src/pair.ts
+++ b/src/pair.ts
@@ -1,0 +1,30 @@
+export class Pair<out A, out B> {
+  public constructor(
+    public readonly fst: A,
+    public readonly snd: B,
+  ) {}
+
+  public static of<A>(value: A): Pair<A, A> {
+    return new Pair(value, value);
+  }
+
+  public map<A, B, C, D>(
+    this: Pair<A, B>,
+    fstMorphism: (fst: A) => C,
+    sndMorphism: (snd: B) => D,
+  ): Pair<C, D> {
+    return new Pair(fstMorphism(this.fst), sndMorphism(this.snd));
+  }
+
+  public associateLeft<A, B, C>(
+    this: Pair<A, Pair<B, C>>,
+  ): Pair<Pair<A, B>, C> {
+    return new Pair(new Pair(this.fst, this.snd.fst), this.snd.snd);
+  }
+
+  public associateRight<A, B, C>(
+    this: Pair<Pair<A, B>, C>,
+  ): Pair<A, Pair<B, C>> {
+    return new Pair(this.fst.fst, new Pair(this.fst.snd, this.snd));
+  }
+}

--- a/src/result.ts
+++ b/src/result.ts
@@ -28,6 +28,10 @@ export class Okay<out A> extends ResultTrait {
   public constructor(public readonly value: A) {
     super();
   }
+
+  public static of<A>(value: A): Okay<A> {
+    return new Okay(value);
+  }
 }
 
 export class Fail<out E> extends ResultTrait {
@@ -37,5 +41,9 @@ export class Fail<out E> extends ResultTrait {
 
   public constructor(public readonly value: E) {
     super();
+  }
+
+  public static of<E>(value: E): Fail<E> {
+    return new Fail(value);
   }
 }

--- a/tests/arbitraries.ts
+++ b/tests/arbitraries.ts
@@ -6,7 +6,7 @@ import type { Result } from "../src/result.js";
 import { Fail, Okay } from "../src/result.js";
 
 export const some = <A>(a: fc.Arbitrary<A>): fc.Arbitrary<Some<A>> =>
-  a.map((value) => new Some(value));
+  a.map(Some.of);
 
 export const none: fc.Arbitrary<None> = fc.constant(None.instance);
 
@@ -14,10 +14,10 @@ export const option = <A>(a: fc.Arbitrary<A>): fc.Arbitrary<Option<A>> =>
   fc.oneof(some(a), none);
 
 export const okay = <A>(a: fc.Arbitrary<A>): fc.Arbitrary<Okay<A>> =>
-  a.map((value) => new Okay(value));
+  a.map(Okay.of);
 
 export const fail = <E>(b: fc.Arbitrary<E>): fc.Arbitrary<Fail<E>> =>
-  b.map((value) => new Fail(value));
+  b.map(Fail.of);
 
 export const result = <E, A>(
   a: fc.Arbitrary<A>,

--- a/tests/arbitraries.ts
+++ b/tests/arbitraries.ts
@@ -2,6 +2,7 @@ import fc from "fast-check";
 
 import type { Option } from "../src/option.js";
 import { None, Some } from "../src/option.js";
+import { Pair } from "../src/pair.js";
 import type { Result } from "../src/result.js";
 import { Fail, Okay } from "../src/result.js";
 
@@ -23,3 +24,8 @@ export const result = <E, A>(
   a: fc.Arbitrary<A>,
   b: fc.Arbitrary<E>,
 ): fc.Arbitrary<Result<E, A>> => fc.oneof(okay(a), fail(b));
+
+export const pair = <A, B>(
+  a: fc.Arbitrary<A>,
+  b: fc.Arbitrary<B>,
+): fc.Arbitrary<Pair<A, B>> => a.chain((a) => b.map((b) => new Pair(a, b)));

--- a/tests/option.test.ts
+++ b/tests/option.test.ts
@@ -48,6 +48,14 @@ const filterAnnihilation = <A>(m: Option<A>): void => {
   expect(m.filter(() => false)).toStrictEqual(None.instance);
 };
 
+const isSomeAndFilter = <A>(m: Option<A>, p: (a: A) => boolean): void => {
+  expect(m.isSomeAnd(p)).toStrictEqual(m.filter(p).isSome);
+};
+
+const isNoneOrFilter = <A>(m: Option<A>, p: (a: A) => boolean): void => {
+  expect(m.isNoneOr(p)).toStrictEqual(m.filter((a) => !p(a)).isNone);
+};
+
 const safeExtractSome = <A>(a: A, x: A): void => {
   expect(new Some(a).safeExtract(x)).toStrictEqual(a);
 };
@@ -155,6 +163,34 @@ describe("Option", () => {
       expect.assertions(100);
 
       fc.assert(fc.property(option(fc.anything()), filterAnnihilation));
+    });
+  });
+
+  describe("isSomeAnd", () => {
+    it("should agree with filter", () => {
+      expect.assertions(100);
+
+      fc.assert(
+        fc.property(
+          option(fc.anything()),
+          fc.func(fc.boolean()),
+          isSomeAndFilter,
+        ),
+      );
+    });
+  });
+
+  describe("isNoneOr", () => {
+    it("should agree with filter", () => {
+      expect.assertions(100);
+
+      fc.assert(
+        fc.property(
+          option(fc.anything()),
+          fc.func(fc.boolean()),
+          isNoneOrFilter,
+        ),
+      );
     });
   });
 

--- a/tests/option.test.ts
+++ b/tests/option.test.ts
@@ -19,7 +19,7 @@ const flatMapLeftIdentity = <A, B>(a: A, k: (a: A) => Option<B>): void => {
 };
 
 const flatMapRightIdentity = <A>(m: Option<A>): void => {
-  expect(m.flatMap((value) => new Some(value))).toStrictEqual(m);
+  expect(m.flatMap(Some.of)).toStrictEqual(m);
 };
 
 const flatMapAssociativity = <A, B, C>(

--- a/tests/pair.test.ts
+++ b/tests/pair.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "@jest/globals";
+import fc from "fast-check";
+
+import { id } from "../src/miscellaneous.js";
+import { Pair } from "../src/pair.js";
+
+import { pair } from "./arbitraries.js";
+
+const mapIdentity = <A, B>(u: Pair<A, B>): void => {
+  expect(u.map(id, id)).toStrictEqual(u);
+};
+
+const ofParametricity = <A, B>(a: A, f: (a: A) => B): void => {
+  expect(Pair.of(a).map(f, f)).toStrictEqual(Pair.of(f(a)));
+};
+
+const associateLeftInverse = <A, B, C>(u: Pair<Pair<A, B>, C>): void => {
+  expect(u.associateRight().associateLeft()).toStrictEqual(u);
+};
+
+const associateRightInverse = <A, B, C>(u: Pair<A, Pair<B, C>>): void => {
+  expect(u.associateLeft().associateRight()).toStrictEqual(u);
+};
+
+describe("Pair", () => {
+  describe("map", () => {
+    it("should preserve identity morphisms", () => {
+      expect.assertions(100);
+      fc.assert(fc.property(pair(fc.anything(), fc.anything()), mapIdentity));
+    });
+  });
+
+  describe("of", () => {
+    it("should be parametric", () => {
+      expect.assertions(100);
+
+      fc.assert(
+        fc.property(fc.anything(), fc.func(fc.anything()), ofParametricity),
+      );
+    });
+  });
+
+  describe("associateLeft", () => {
+    it("should be the inverse of associateRight", () => {
+      expect.assertions(100);
+
+      fc.assert(
+        fc.property(
+          pair(pair(fc.anything(), fc.anything()), fc.anything()),
+          associateLeftInverse,
+        ),
+      );
+    });
+  });
+
+  describe("associateRight", () => {
+    it("should be the inverse of associateLeft", () => {
+      expect.assertions(100);
+
+      fc.assert(
+        fc.property(
+          pair(fc.anything(), pair(fc.anything(), fc.anything())),
+          associateRightInverse,
+        ),
+      );
+    });
+  });
+});


### PR DESCRIPTION
The `isSomeAnd` and `isNoneOr` methods are convenience methods. They are not strictly required because you can can the same result by using the `filter` method in conjunction with `isSome` and `isNone` respectively. However, they are more descriptive and easier to read.

Although you can create instances of `Some`, `Okay`, and `Fail` using the `new` keyword directly, sometimes you need to pass the constructors as regular functions to some higher-order functions. In these cases, its better to pass the static methods instead of creating new closures.

The `Pair` data type is a commonly used data type in functional programming. Hence, it makes sense to add it to the library.

I implemented methods of the `Applicative`, `Alternative`, and `Traversable` interfaces in the `OptionTrait` class. I also added several convenience methods such as `replace`, `flatten`, etc.