### PR TITLE
✨ Add type predicate overloads and `toString` to `Option`

### DIFF
--- a/src/option.ts
+++ b/src/option.ts
@@ -11,6 +11,10 @@ abstract class OptionTrait {
 
   public abstract readonly isNone: boolean;
 
+  public toString<A>(this: Option<A>): string {
+    return this.isSome ? `Some(${String(this.value)})` : "None";
+  }
+
   public map<A, B>(this: Option<A>, morphism: (value: A) => B): Option<B> {
     return this.isSome ? new Some(morphism(this.value)) : None.instance;
   }

--- a/src/option.ts
+++ b/src/option.ts
@@ -48,6 +48,14 @@ abstract class OptionTrait {
     return this.isSome ? this.value : None.instance;
   }
 
+  public filter<A, B extends A>(
+    this: Option<A>,
+    predicate: (value: A) => value is B,
+  ): Option<B>;
+  public filter<A>(
+    this: Option<A>,
+    predicate: (value: A) => boolean,
+  ): Option<A>;
   public filter<A>(
     this: Option<A>,
     predicate: (value: A) => boolean,
@@ -55,6 +63,14 @@ abstract class OptionTrait {
     return this.isSome && predicate(this.value) ? this : None.instance;
   }
 
+  public isSomeAnd<A, B extends A>(
+    this: Option<A>,
+    predicate: (value: A) => value is B,
+  ): this is Option<B>;
+  public isSomeAnd<A>(
+    this: Option<A>,
+    predicate: (value: A) => boolean,
+  ): boolean;
   public isSomeAnd<A>(
     this: Option<A>,
     predicate: (value: A) => boolean,
@@ -62,6 +78,14 @@ abstract class OptionTrait {
     return this.isSome && predicate(this.value);
   }
 
+  public isNoneOr<A, B extends A>(
+    this: Option<A>,
+    predicate: (value: A) => value is B,
+  ): this is Option<B>;
+  public isNoneOr<A>(
+    this: Option<A>,
+    predicate: (value: A) => boolean,
+  ): boolean;
   public isNoneOr<A>(
     this: Option<A>,
     predicate: (value: A) => boolean,

--- a/tests/option.test.ts
+++ b/tests/option.test.ts
@@ -12,6 +12,14 @@ import { Fail, Okay } from "../src/result.js";
 
 import { none, option, pair, result } from "./arbitraries.js";
 
+const toStringSome = <A>(a: A): void => {
+  expect(new Some(a).toString()).toStrictEqual(`Some(${String(a)})`);
+};
+
+const toStringNone = (u: None): void => {
+  expect(u.toString()).toStrictEqual("None");
+};
+
 const mapIdentity = <A>(u: Option<A>): void => {
   expect(u.map(id)).toStrictEqual(u);
 };
@@ -198,6 +206,20 @@ const iterateNone = (m: None): void => {
 };
 
 describe("Option", () => {
+  describe("toString", () => {
+    it("should convert Some to a string", () => {
+      expect.assertions(100);
+
+      fc.assert(fc.property(fc.anything(), toStringSome));
+    });
+
+    it("should convert None to a string", () => {
+      expect.assertions(100);
+
+      fc.assert(fc.property(none, toStringNone));
+    });
+  });
+
   describe("map", () => {
     it("should preserve identity morphisms", () => {
       expect.assertions(100);


### PR DESCRIPTION
The `filter`, `isSomeAnd`, and `isNoneOr` methods accept type predicates as input. We can use this to narrow the type of the result, in case of `filter`, or the type of `this`, in case of `isSomeAnd` and `isNoneOr`.

The `toString` method is very useful when we want to debug an `Option` value. For example, when logging an `Option` to the console.