### PR TITLE
✅ Check whether the error is a `TypeError` on fail

### DIFF
--- a/tests/option.test.ts
+++ b/tests/option.test.ts
@@ -13,7 +13,11 @@ import { Fail, Okay } from "../src/result.js";
 import { none, option, pair, result } from "./arbitraries.js";
 
 const toStringSome = <A>(a: A): void => {
-  expect(new Some(a).toString()).toStrictEqual(`Some(${String(a)})`);
+  try {
+    expect(new Some(a).toString()).toStrictEqual(`Some(${String(a)})`);
+  } catch (error) {
+    expect(error).toBeInstanceOf(TypeError);
+  }
 };
 
 const toStringNone = (u: None): void => {


### PR DESCRIPTION
Converting an arbitrary value to a string can result in a `TypeError` if the value doesn't have a callable `toString` or if `toString` returns an object, and if it doesn't have a callable `valueOf` or if `valueOf` returns an object. Hence, we need to add a test for this error.