### PR TITLE
✨ Add `Ordering`, `Setoid`, and `Order` types

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -6,3 +6,13 @@ export class UnsafeExtractError extends Exception {
     this.setName("UnsafeExtractError");
   }
 }
+
+export class ComparabilityError<out A> extends Exception {
+  public constructor(
+    public readonly fst: A,
+    public readonly snd: A,
+  ) {
+    super("The `fst` and `snd` values are not comparable.");
+    this.setName("ComparabilityError");
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./exceptions.js";
 export * from "./miscellaneous.js";
 export * from "./option.js";
+export * from "./order.js";
 export * from "./ordering.js";
 export * from "./pair.js";
 export * from "./result.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./exceptions.js";
 export * from "./miscellaneous.js";
 export * from "./option.js";
+export * from "./ordering.js";
 export * from "./pair.js";
 export * from "./result.js";

--- a/src/order.ts
+++ b/src/order.ts
@@ -1,0 +1,139 @@
+import { ComparabilityError } from "./errors.js";
+import type { Option } from "./option.js";
+import { None, Some } from "./option.js";
+import type { Ordering } from "./ordering.js";
+import { isNotLess, isNotMore } from "./ordering.js";
+
+export abstract class Setoid<in A> {
+  public abstract readonly isSame: (x: A, y: A) => boolean;
+
+  public readonly isNotSame = (x: A, y: A): boolean => !this.isSame(x, y);
+}
+
+export abstract class Order<in out A> extends Setoid<A> {
+  public abstract readonly isLess: (x: A, y: A) => boolean;
+
+  public readonly isNotLess = (x: A, y: A): boolean =>
+    this.compare(x, y).isSomeAnd(isNotLess);
+
+  public abstract readonly isMore: (x: A, y: A) => boolean;
+
+  public readonly isNotMore = (x: A, y: A): boolean =>
+    this.compare(x, y).isSomeAnd(isNotMore);
+
+  public readonly compare = (x: A, y: A): Option<Ordering> => {
+    if (this.isSame(x, y)) return new Some("=");
+    if (this.isLess(x, y)) return new Some("<");
+    if (this.isMore(x, y)) return new Some(">");
+    return None.instance;
+  };
+
+  public readonly unsafeCompare = (x: A, y: A): Ordering =>
+    this.compare(x, y).unsafeExtract(new ComparabilityError(x, y));
+
+  public readonly max = (x: A, y: A): A =>
+    isNotLess(this.unsafeCompare(x, y)) ? x : y;
+
+  public readonly min = (x: A, y: A): A =>
+    isNotMore(this.unsafeCompare(x, y)) ? x : y;
+
+  public readonly clamp = (value: A, lower: A, upper: A): A =>
+    this.min(this.max(value, lower), upper);
+}
+
+export class StringOrder extends Order<string> {
+  public override readonly isSame = (x: string, y: string): boolean => x === y;
+
+  public override readonly isNotSame = (x: string, y: string): boolean =>
+    x !== y;
+
+  public override readonly isLess = (x: string, y: string): boolean => x < y;
+
+  public override readonly isNotLess = (x: string, y: string): boolean =>
+    x >= y;
+
+  public override readonly isMore = (x: string, y: string): boolean => x > y;
+
+  public override readonly isNotMore = (x: string, y: string): boolean =>
+    x <= y;
+
+  public static readonly instance = new StringOrder();
+}
+
+export class NumberOrder extends Order<number> {
+  public override readonly isSame: (x: number, y: number) => boolean =
+    Object.is;
+
+  public override readonly isLess = (x: number, y: number): boolean => x < y;
+
+  public override readonly isNotLess = (x: number, y: number): boolean =>
+    x >= y;
+
+  public override readonly isMore = (x: number, y: number): boolean => x > y;
+
+  public override readonly isNotMore = (x: number, y: number): boolean =>
+    x <= y;
+
+  public override readonly max: (x: number, y: number) => number = Math.max;
+
+  public override readonly min: (x: number, y: number) => number = Math.min;
+
+  public static readonly instance = new NumberOrder();
+}
+
+export class BigIntOrder extends Order<bigint> {
+  public override readonly isSame = (x: bigint, y: bigint): boolean => x === y;
+
+  public override readonly isNotSame = (x: bigint, y: bigint): boolean =>
+    x !== y;
+
+  public override readonly isLess = (x: bigint, y: bigint): boolean => x < y;
+
+  public override readonly isNotLess = (x: bigint, y: bigint): boolean =>
+    x >= y;
+
+  public override readonly isMore = (x: bigint, y: bigint): boolean => x > y;
+
+  public override readonly isNotMore = (x: bigint, y: bigint): boolean =>
+    x <= y;
+
+  public static readonly instance = new BigIntOrder();
+}
+
+export class BooleanOrder extends Order<boolean> {
+  public override readonly isSame = (x: boolean, y: boolean): boolean =>
+    x === y;
+
+  public override readonly isNotSame = (x: boolean, y: boolean): boolean =>
+    x !== y;
+
+  public override readonly isLess = (x: boolean, y: boolean): boolean => x < y;
+
+  public override readonly isNotLess = (x: boolean, y: boolean): boolean =>
+    x >= y;
+
+  public override readonly isMore = (x: boolean, y: boolean): boolean => x > y;
+
+  public override readonly isNotMore = (x: boolean, y: boolean): boolean =>
+    x <= y;
+
+  public static readonly instance = new BooleanOrder();
+}
+
+export class DateOrder extends Order<Date> {
+  public override readonly isSame = (x: Date, y: Date): boolean =>
+    NumberOrder.instance.isSame(x.getTime(), y.getTime());
+
+  public override readonly isNotSame = (x: Date, y: Date): boolean =>
+    NumberOrder.instance.isNotSame(x.getTime(), y.getTime());
+
+  public override readonly isLess = (x: Date, y: Date): boolean => x < y;
+
+  public override readonly isNotLess = (x: Date, y: Date): boolean => x >= y;
+
+  public override readonly isMore = (x: Date, y: Date): boolean => x > y;
+
+  public override readonly isNotMore = (x: Date, y: Date): boolean => x <= y;
+
+  public static readonly instance = new DateOrder();
+}

--- a/src/ordering.ts
+++ b/src/ordering.ts
@@ -1,0 +1,13 @@
+export type Ordering = "<" | "=" | ">";
+
+export const isSame = (x: Ordering): x is "=" => x === "=";
+
+export const isNotSame = (x: Ordering): x is "<" | ">" => x !== "=";
+
+export const isLess = (x: Ordering): x is "<" => x === "<";
+
+export const isNotLess = (x: Ordering): x is ">" | "=" => x !== "<";
+
+export const isMore = (x: Ordering): x is ">" => x === ">";
+
+export const isNotMore = (x: Ordering): x is "<" | "=" => x !== ">";

--- a/tests/arbitraries.ts
+++ b/tests/arbitraries.ts
@@ -2,6 +2,7 @@ import fc from "fast-check";
 
 import type { Option } from "../src/option.js";
 import { None, Some } from "../src/option.js";
+import type { Ordering } from "../src/ordering.js";
 import { Pair } from "../src/pair.js";
 import type { Result } from "../src/result.js";
 import { Fail, Okay } from "../src/result.js";
@@ -29,3 +30,9 @@ export const pair = <A, B>(
   a: fc.Arbitrary<A>,
   b: fc.Arbitrary<B>,
 ): fc.Arbitrary<Pair<A, B>> => a.chain((a) => b.map((b) => new Pair(a, b)));
+
+export const ordering: fc.Arbitrary<Ordering> = fc.oneof(
+  fc.constant("<" as const),
+  fc.constant("=" as const),
+  fc.constant(">" as const),
+);

--- a/tests/order.test.ts
+++ b/tests/order.test.ts
@@ -1,0 +1,347 @@
+import { describe, expect, it } from "@jest/globals";
+import fc from "fast-check";
+
+import { ComparabilityError } from "../src/errors.js";
+import { Some } from "../src/option.js";
+import type { Setoid } from "../src/order.js";
+import {
+  BigIntOrder,
+  BooleanOrder,
+  DateOrder,
+  NumberOrder,
+  Order,
+  StringOrder,
+} from "../src/order.js";
+import * as ordering from "../src/ordering.js";
+
+const testSetoid = <A>(
+  name: string,
+  value: fc.Arbitrary<A>,
+  setoid: Setoid<A>,
+): void => {
+  const { isSame, isNotSame } = setoid;
+
+  const isSameReflexivity = (x: A): void => {
+    expect(isSame(x, x)).toStrictEqual(true);
+  };
+
+  const isSameSymmetry = (x: A, y: A): void => {
+    expect(isSame(x, y)).toStrictEqual(isSame(y, x));
+  };
+
+  const isSameTransitivity = (x: A, y: A, z: A): void => {
+    if (isSame(x, y) && isSame(y, z)) {
+      expect(isSame(x, z)).toStrictEqual(true);
+    } else {
+      expect(isSame(x, z)).toStrictEqual(expect.anything());
+    }
+  };
+
+  const isSameExtensionality = <B>(x: A, y: A, f: (a: A) => B): void => {
+    if (isSame(x, y)) {
+      expect(f(x)).toStrictEqual(f(y));
+    } else {
+      expect(f(x)).toStrictEqual(f(x));
+    }
+  };
+
+  const isNotSameDefinition = (x: A, y: A): void => {
+    expect(isNotSame(x, y)).toStrictEqual(!isSame(x, y));
+  };
+
+  describe(`Setoid<${name}>`, () => {
+    describe("isSame", () => {
+      it("should be reflexive", () => {
+        expect.assertions(100);
+
+        fc.assert(fc.property(value, isSameReflexivity));
+      });
+
+      it("should be symmetric", () => {
+        expect.assertions(100);
+
+        fc.assert(fc.property(value, value, isSameSymmetry));
+      });
+
+      it("should be transitive", () => {
+        expect.assertions(100);
+
+        fc.assert(fc.property(value, value, value, isSameTransitivity));
+      });
+
+      it("should respect function extensionality", () => {
+        expect.assertions(100);
+
+        fc.assert(
+          fc.property(
+            value,
+            value,
+            fc.func(fc.anything()),
+            isSameExtensionality,
+          ),
+        );
+      });
+    });
+
+    describe("isNotSame", () => {
+      it("should agree with isSame", () => {
+        expect.assertions(100);
+
+        fc.assert(fc.property(value, value, isNotSameDefinition));
+      });
+    });
+  });
+};
+
+const testOrder = <A>(
+  name: string,
+  value: fc.Arbitrary<A>,
+  order: Order<A>,
+): void => {
+  const {
+    isLess,
+    isNotLess,
+    isMore,
+    isNotMore,
+    compare,
+    unsafeCompare,
+    max,
+    min,
+    clamp,
+    ...setoid
+  } = order;
+
+  const { isSame } = setoid;
+
+  testSetoid(name, value, setoid);
+
+  const isLessIrreflexivity = (x: A): void => {
+    expect(isLess(x, x)).toStrictEqual(false);
+  };
+
+  const isLessTransitive = (x: A, y: A, z: A): void => {
+    if (isLess(x, y) && isLess(y, z)) {
+      expect(isLess(x, z)).toStrictEqual(true);
+    } else {
+      expect(isLess(x, z)).toStrictEqual(expect.anything());
+    }
+  };
+
+  const isLessDuality = (x: A, y: A): void => {
+    expect(isLess(x, y)).toStrictEqual(isMore(y, x));
+  };
+
+  const isNotLessDefinition = (x: A, y: A): void => {
+    expect(isNotLess(x, y)).toStrictEqual(isMore(x, y) || isSame(x, y));
+  };
+
+  const isMoreIrreflexivity = (x: A): void => {
+    expect(isMore(x, x)).toStrictEqual(false);
+  };
+
+  const isMoreTransitive = (x: A, y: A, z: A): void => {
+    if (isMore(x, y) && isMore(y, z)) {
+      expect(isMore(x, z)).toStrictEqual(true);
+    } else {
+      expect(isMore(x, z)).toStrictEqual(expect.anything());
+    }
+  };
+
+  const isMoreDuality = (x: A, y: A): void => {
+    expect(isMore(x, y)).toStrictEqual(isLess(y, x));
+  };
+
+  const isNotMoreDefinition = (x: A, y: A): void => {
+    expect(isNotMore(x, y)).toStrictEqual(isLess(x, y) || isSame(x, y));
+  };
+
+  const compareIsSame = (x: A, y: A): void => {
+    if (isSame(x, y)) {
+      expect(compare(x, y)).toStrictEqual(new Some("="));
+    } else {
+      expect(compare(x, y)).not.toStrictEqual(new Some("="));
+    }
+  };
+
+  const compareIsLess = (x: A, y: A): void => {
+    if (isLess(x, y)) {
+      expect(compare(x, y)).toStrictEqual(new Some("<"));
+    } else {
+      expect(compare(x, y)).not.toStrictEqual(new Some("<"));
+    }
+  };
+
+  const compareIsMore = (x: A, y: A): void => {
+    if (isMore(x, y)) {
+      expect(compare(x, y)).toStrictEqual(new Some(">"));
+    } else {
+      expect(compare(x, y)).not.toStrictEqual(new Some(">"));
+    }
+  };
+
+  const unsafeCompareDefinition = (x: A, y: A): void => {
+    try {
+      expect(new Some(unsafeCompare(x, y))).toStrictEqual(compare(x, y));
+    } catch (error) {
+      expect(error).toBeInstanceOf(ComparabilityError);
+    }
+  };
+
+  const maxDefinition = (x: A, y: A): void => {
+    try {
+      const expected = ordering.isNotLess(unsafeCompare(x, y)) ? x : y;
+      expect(max(x, y)).toStrictEqual(expected);
+    } catch (error) {
+      expect(error).toBeInstanceOf(ComparabilityError);
+    }
+  };
+
+  const minDefinition = (x: A, y: A): void => {
+    try {
+      const expected = ordering.isNotMore(unsafeCompare(x, y)) ? x : y;
+      expect(min(x, y)).toStrictEqual(expected);
+    } catch (error) {
+      expect(error).toBeInstanceOf(ComparabilityError);
+    }
+  };
+
+  const clampDefinition = (value: A, lower: A, upper: A): void => {
+    try {
+      expect(clamp(value, lower, upper)).toStrictEqual(
+        min(max(value, lower), upper),
+      );
+    } catch (error) {
+      expect(error).toBeInstanceOf(ComparabilityError);
+    }
+  };
+
+  describe(`Order<${name}>`, () => {
+    describe("isLess", () => {
+      it("should be irreflexive", () => {
+        expect.assertions(100);
+
+        fc.assert(fc.property(value, isLessIrreflexivity));
+      });
+
+      it("should be transitive", () => {
+        expect.assertions(100);
+
+        fc.assert(fc.property(value, value, value, isLessTransitive));
+      });
+
+      it("should be the dual of isMore", () => {
+        expect.assertions(100);
+
+        fc.assert(fc.property(value, value, isLessDuality));
+      });
+    });
+
+    describe("isNotLess", () => {
+      it("should agree with isMore or isSame", () => {
+        expect.assertions(100);
+
+        fc.assert(fc.property(value, value, isNotLessDefinition));
+      });
+    });
+
+    describe("isMore", () => {
+      it("should be irreflexive", () => {
+        expect.assertions(100);
+
+        fc.assert(fc.property(value, isMoreIrreflexivity));
+      });
+
+      it("should be transitive", () => {
+        expect.assertions(100);
+
+        fc.assert(fc.property(value, value, value, isMoreTransitive));
+      });
+
+      it("should be the dual of isLess", () => {
+        expect.assertions(100);
+
+        fc.assert(fc.property(value, value, isMoreDuality));
+      });
+    });
+
+    describe("isNotMore", () => {
+      it("should agree with isLess or isSame", () => {
+        expect.assertions(100);
+
+        fc.assert(fc.property(value, value, isNotMoreDefinition));
+      });
+    });
+
+    describe("compare", () => {
+      it("should agree with isSame", () => {
+        expect.assertions(100);
+
+        fc.assert(fc.property(value, value, compareIsSame));
+      });
+
+      it("should agree with isLess", () => {
+        expect.assertions(100);
+
+        fc.assert(fc.property(value, value, compareIsLess));
+      });
+
+      it("should agree with isMore", () => {
+        expect.assertions(100);
+
+        fc.assert(fc.property(value, value, compareIsMore));
+      });
+    });
+
+    describe("unsafeCompare", () => {
+      it("should agree with compare", () => {
+        expect.assertions(100);
+
+        fc.assert(fc.property(value, value, unsafeCompareDefinition));
+      });
+    });
+
+    describe("max", () => {
+      it("should agree with unsafeCompare", () => {
+        expect.assertions(100);
+
+        fc.assert(fc.property(value, value, maxDefinition));
+      });
+    });
+
+    describe("min", () => {
+      it("should agree with unsafeCompare", () => {
+        expect.assertions(100);
+
+        fc.assert(fc.property(value, value, minDefinition));
+      });
+    });
+
+    describe("clamp", () => {
+      it("should agree with min and max", () => {
+        expect.assertions(100);
+
+        fc.assert(fc.property(value, value, value, clampDefinition));
+      });
+    });
+  });
+};
+
+class UnknownOrder extends Order<unknown> {
+  public override readonly isSame: (x: unknown, y: unknown) => boolean =
+    Object.is;
+
+  public override readonly isLess: (x: unknown, y: unknown) => boolean = () =>
+    false;
+
+  public override readonly isMore: (x: unknown, y: unknown) => boolean = () =>
+    false;
+
+  public static readonly instance = new UnknownOrder();
+}
+
+testOrder("unknown", fc.anything(), UnknownOrder.instance);
+testOrder("string", fc.string(), StringOrder.instance);
+testOrder("number", fc.double(), NumberOrder.instance);
+testOrder("bigint", fc.bigUint(), BigIntOrder.instance);
+testOrder("boolean", fc.boolean(), BooleanOrder.instance);
+testOrder("Date", fc.date(), DateOrder.instance);

--- a/tests/order.test.ts
+++ b/tests/order.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "@jest/globals";
 import fc from "fast-check";
 
 import { ComparabilityError } from "../src/errors.js";
-import { Some } from "../src/option.js";
+import { OptionOrder, OptionSetoid, Some } from "../src/option.js";
 import type { Setoid } from "../src/order.js";
 import {
   BigIntOrder,
@@ -13,6 +13,8 @@ import {
   StringOrder,
 } from "../src/order.js";
 import * as ordering from "../src/ordering.js";
+
+import { option } from "./arbitraries.js";
 
 const testSetoid = <A>(
   name: string,
@@ -345,3 +347,15 @@ testOrder("number", fc.double(), NumberOrder.instance);
 testOrder("bigint", fc.bigUint(), BigIntOrder.instance);
 testOrder("boolean", fc.boolean(), BooleanOrder.instance);
 testOrder("Date", fc.date(), DateOrder.instance);
+
+testSetoid(
+  "Option<string>",
+  option(fc.string()),
+  new OptionSetoid(StringOrder.instance),
+);
+
+testOrder(
+  "Option<number>",
+  option(fc.double()),
+  new OptionOrder(NumberOrder.instance),
+);

--- a/tests/ordering.test.ts
+++ b/tests/ordering.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "@jest/globals";
+import fc from "fast-check";
+
+import type { Ordering } from "../src/ordering.js";
+import {
+  isLess,
+  isMore,
+  isNotLess,
+  isNotMore,
+  isNotSame,
+  isSame,
+} from "../src/ordering.js";
+
+import { ordering } from "./arbitraries.js";
+
+const isSameDefinition = (x: Ordering): void => {
+  expect(isSame(x)).toStrictEqual(!isNotSame(x));
+};
+
+const isLessDefinition = (x: Ordering): void => {
+  expect(isLess(x)).toStrictEqual(!isNotLess(x));
+};
+
+const isMoreDefinition = (x: Ordering): void => {
+  expect(isMore(x)).toStrictEqual(!isNotMore(x));
+};
+
+describe("Ordering", () => {
+  describe("isSame", () => {
+    it("should agree with isNotSame", () => {
+      expect.assertions(100);
+
+      fc.assert(fc.property(ordering, isSameDefinition));
+    });
+  });
+
+  describe("isLess", () => {
+    it("should agree with isNotLess", () => {
+      expect.assertions(100);
+
+      fc.assert(fc.property(ordering, isLessDefinition));
+    });
+  });
+
+  describe("isMore", () => {
+    it("should agree with isNotMore", () => {
+      expect.assertions(100);
+
+      fc.assert(fc.property(ordering, isMoreDefinition));
+    });
+  });
+});


### PR DESCRIPTION
The `Ordering` denotes whether a value is more, less, or the same as another value. It's useful in defining the `Setoid` and `Order` abstract classes.

The `Setoid` and `Order` classes are useful abstractions from functional programming. They correspond to the `Eq` and `Ord` type classes in Haskell and Rust.

The `OptionSetoid` and `OptionOrder` classes allow you to create an instance of `Setoid` and `Order` respectively for `Option` types. They take a `Setoid` or `Order` respectively as an input and return another `Setoid` or `Order` respectively as an output.
