### PR TITLE
💥 Split `Order` into `PartialOrder` and `TotalOrder`

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -6,13 +6,3 @@ export class UnsafeExtractError extends Exception {
     this.setName("UnsafeExtractError");
   }
 }
-
-export class ComparabilityError<out A> extends Exception {
-  public constructor(
-    public readonly fst: A,
-    public readonly snd: A,
-  ) {
-    super("The `fst` and `snd` values are not comparable.");
-    this.setName("ComparabilityError");
-  }
-}


### PR DESCRIPTION
The `Order` class should be split into a `PartialOrder` and `TotalOrder` class because some data types such as `number` and `Date` aren't total orders because `NaN` and `new Date(NaN)` are not comparable to other values respectively.

I also removed the `unsafeCompare` function and the `ComparabilityError` class because `unsafeCompare(x, y)` is the same as `compare(x, y)` followed by `unsafeExtract` on the result. This also allows the user to specify the exception or error message they want.

Next, I converted the `Setoid`, `PartialOrder`, and `TotalOrder` classes to interfaces instead. Though it's nice to have default implementations of class methods, it leads to more redundancy when implementing a data type with a `Setoid`, `PartialOrder`, and `TotalOrder` classes. This is because we can't have multiple inheritance. Hence, we can either inherit from the default implementation or we can inherit from the superclass. It's better to inherit from the superclass.

Making these changes also revealed several bugs in our implementation of `DateOrder`, which I promptly fixed. I also updated the unit tests, and tweaked the fast-check arbitraries to check all the edge cases. Turns out that not relying on default implementations increases the number of edge cases to handle. This is a good thing because it makes our tests more robust.

Finally, I made a miscellaneous changes such as converting a private class field into a public class field, and cleaning up a few fast-check test property functions.