### PR TITLE
✨ Add a `Semigroup` interface and implementations

### DIFF
--- a/src/bool.ts
+++ b/src/bool.ts
@@ -2,6 +2,7 @@ import type { Option } from "./option.js";
 import { Some } from "./option.js";
 import type { TotalOrder } from "./order.js";
 import type { Ordering } from "./ordering.js";
+import type { Semigroup } from "./semigroup.js";
 
 export class Bool implements TotalOrder<Bool> {
   public constructor(public readonly value: boolean) {}
@@ -50,5 +51,25 @@ export class Bool implements TotalOrder<Bool> {
 
   public clamp(this: Bool, lower: Bool, upper: Bool): Bool {
     return this.max(lower).min(upper);
+  }
+}
+
+export class Any extends Bool implements Semigroup<Any> {
+  public static override of(value: boolean): Any {
+    return new Any(value);
+  }
+
+  public append(this: Any, that: Any): Any {
+    return new Any(this.value || that.value);
+  }
+}
+
+export class All extends Bool implements Semigroup<All> {
+  public static override of(value: boolean): All {
+    return new All(value);
+  }
+
+  public append(this: All, that: All): All {
+    return new All(this.value && that.value);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,4 +9,5 @@ export * from "./order.js";
 export * from "./ordering.js";
 export * from "./pair.js";
 export * from "./result.js";
+export * from "./semigroup.js";
 export * from "./text.js";

--- a/src/integer.ts
+++ b/src/integer.ts
@@ -2,6 +2,7 @@ import type { Option } from "./option.js";
 import { Some } from "./option.js";
 import type { TotalOrder } from "./order.js";
 import type { Ordering } from "./ordering.js";
+import type { Semigroup } from "./semigroup.js";
 
 export class Integer implements TotalOrder<Integer> {
   public constructor(public readonly value: bigint) {}
@@ -50,5 +51,25 @@ export class Integer implements TotalOrder<Integer> {
 
   public clamp(this: Integer, lower: Integer, upper: Integer): Integer {
     return this.max(lower).min(upper);
+  }
+}
+
+export class Sum extends Integer implements Semigroup<Sum> {
+  public static override of(value: bigint): Sum {
+    return new Sum(value);
+  }
+
+  public append(this: Sum, that: Sum): Sum {
+    return new Sum(this.value + that.value);
+  }
+}
+
+export class Product extends Integer implements Semigroup<Product> {
+  public static override of(value: bigint): Product {
+    return new Product(value);
+  }
+
+  public append(this: Product, that: Product): Product {
+    return new Product(this.value * that.value);
   }
 }

--- a/src/option.ts
+++ b/src/option.ts
@@ -5,10 +5,13 @@ import type { Ordering } from "./ordering.js";
 import { Pair } from "./pair.js";
 import type { Result } from "./result.js";
 import { Fail, Okay } from "./result.js";
+import type { Semigroup } from "./semigroup.js";
 
 export type Option<A> = Some<A> | None;
 
-abstract class OptionTrait implements TotalOrder<Option<never>> {
+abstract class OptionTrait
+  implements Semigroup<Option<never>>, TotalOrder<Option<never>>
+{
   public abstract readonly isSome: boolean;
 
   public abstract readonly isNone: boolean;
@@ -138,6 +141,15 @@ abstract class OptionTrait implements TotalOrder<Option<never>> {
 
   public toResult<E, A>(this: Option<A>, defaultValue: E): Result<E, A> {
     return this.isSome ? new Okay(this.value) : new Fail(defaultValue);
+  }
+
+  public append<A extends Semigroup<A>>(
+    this: Option<A>,
+    that: Option<A>,
+  ): Option<A> {
+    if (this.isNone) return that;
+    if (that.isNone) return this;
+    return new Some(this.value.append(that.value));
   }
 
   public isSame<A extends Setoid<A>>(

--- a/src/semigroup.ts
+++ b/src/semigroup.ts
@@ -1,0 +1,3 @@
+export interface Semigroup<in out A> {
+  append: (this: A, that: A) => A;
+}

--- a/src/text.ts
+++ b/src/text.ts
@@ -2,12 +2,17 @@ import type { Option } from "./option.js";
 import { Some } from "./option.js";
 import type { TotalOrder } from "./order.js";
 import type { Ordering } from "./ordering.js";
+import type { Semigroup } from "./semigroup.js";
 
-export class Text implements TotalOrder<Text> {
+export class Text implements Semigroup<Text>, TotalOrder<Text> {
   public constructor(public readonly value: string) {}
 
   public static of(value: string): Text {
     return new Text(value);
+  }
+
+  public append(this: Text, that: Text): Text {
+    return new Text(`${this.value}${that.value}`);
   }
 
   public isSame(this: Text, that: Text): boolean {

--- a/tests/order.test.ts
+++ b/tests/order.test.ts
@@ -325,25 +325,18 @@ const double = fc
   )
   .map(Double.of);
 
+const datetime = fc
+  .date({
+    min: new Date(0),
+    max: new Date(9),
+    noInvalidDate: false,
+  })
+  .map(DateTime.of);
+
 testPartialOrder("Unknown", fc.anything().map(Unknown.of));
-
 testTotalOrder("Text", fc.string().map(Text.of));
-
 testTotalOrder("Double", double);
-
 testTotalOrder("Integer", fc.bigUint(9n).map(Integer.of));
-
 testTotalOrder("Bool", fc.boolean().map(Bool.of));
-
-testTotalOrder(
-  "DateTime",
-  fc
-    .date({
-      min: new Date(0),
-      max: new Date(9),
-      noInvalidDate: false,
-    })
-    .map(DateTime.of),
-);
-
+testTotalOrder("DateTime", datetime);
 testTotalOrder("Option<Double>", option(double));

--- a/tests/semigroup.test.ts
+++ b/tests/semigroup.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "@jest/globals";
+import fc from "fast-check";
+
+import { All, Any } from "../src/bool.js";
+import { Product, Sum } from "../src/integer.js";
+import type { Setoid } from "../src/order.js";
+import type { Semigroup } from "../src/semigroup.js";
+import { Text } from "../src/text.js";
+
+import { option } from "./arbitraries.js";
+
+const testSemigroup = <A extends Semigroup<A> & Setoid<A>>(
+  name: string,
+  value: fc.Arbitrary<A>,
+): void => {
+  const appendAssociativity = (x: A, y: A, z: A): void => {
+    expect(x.append(y.append(z)).isSame(x.append(y).append(z))).toStrictEqual(
+      true,
+    );
+  };
+
+  describe(`Semigroup<${name}>`, () => {
+    describe("append", () => {
+      it("should be associative", () => {
+        expect.assertions(100);
+
+        fc.assert(fc.property(value, value, value, appendAssociativity));
+      });
+    });
+  });
+};
+
+testSemigroup("Text", fc.string().map(Text.of));
+testSemigroup("Sum", fc.bigUint().map(Sum.of));
+testSemigroup("Product", fc.bigUint().map(Product.of));
+testSemigroup("Any", fc.boolean().map(Any.of));
+testSemigroup("All", fc.boolean().map(All.of));
+testSemigroup("Option<Text>", option(fc.string().map(Text.of)));


### PR DESCRIPTION
Semigroups are commonly used algebraic structures in functional programming. Hence, I added a `Semigroup` interface and several implementations such as `Text`, `Sum`, `Product`, `Any`, `All`, and `Option<A>`.
