### PR TITLE
✅ Remove `Setoid` constraint from `testSemigroup`

### DIFF
--- a/tests/semigroup.test.ts
+++ b/tests/semigroup.test.ts
@@ -3,20 +3,17 @@ import fc from "fast-check";
 
 import { All, Any } from "../src/bool.js";
 import { Product, Sum } from "../src/integer.js";
-import type { Setoid } from "../src/order.js";
 import type { Semigroup } from "../src/semigroup.js";
 import { Text } from "../src/text.js";
 
 import { option } from "./arbitraries.js";
 
-const testSemigroup = <A extends Semigroup<A> & Setoid<A>>(
+const testSemigroup = <A extends Semigroup<A>>(
   name: string,
   value: fc.Arbitrary<A>,
 ): void => {
   const appendAssociativity = (x: A, y: A, z: A): void => {
-    expect(x.append(y.append(z)).isSame(x.append(y).append(z))).toStrictEqual(
-      true,
-    );
+    expect(x.append(y.append(z))).toStrictEqual(x.append(y).append(z));
   };
 
   describe(`Semigroup<${name}>`, () => {


### PR DESCRIPTION
We don't need the `Setoid` constraint to test whether an instance of `Semigroup` obeys the associativity law.