### PR TITLE
✨ Add `fromGenerator` function and `effect` method

### DIFF
--- a/src/option.ts
+++ b/src/option.ts
@@ -244,6 +244,19 @@ abstract class OptionTrait
   public *[Symbol.iterator]<A>(this: Option<A>): Generator<A, void, undefined> {
     if (this.isSome) yield this.value;
   }
+
+  public *effectMap<A, B>(
+    this: Option<A>,
+    morphism: (value: A) => B,
+  ): Generator<Option<A>, B, A> {
+    const value = yield this;
+    return morphism(value);
+  }
+
+  public *effect<A>(this: Option<A>): Generator<Option<A>, A, A> {
+    const value = yield this;
+    return value;
+  }
 }
 
 export class Some<out A> extends OptionTrait {
@@ -288,3 +301,20 @@ export function fromValue<A>(
 ): Option<A> {
   return predicate(value) ? new Some(value) : None.instance;
 }
+
+// TODO: <A, B>(getGenerator: () => Generator<Option<A>, B, A>) => Option<B>
+export const fromGenerator = <A>(
+  getGenerator: () => Generator<Option<unknown>, A, unknown>,
+): Option<A> => {
+  const generator = getGenerator();
+
+  let result = generator.next();
+
+  while (!result.done) {
+    const option = result.value;
+    if (option.isNone) return None.instance;
+    result = generator.next(option.value);
+  }
+
+  return new Some(result.value);
+};


### PR DESCRIPTION
The `fromGenerator` function and the `effect` method can be used to write monadic code à la do notation in Haskell or `async…await` syntax in JavaScript. The `fromGenerator` function converts a generator function into an `Option` and the `effect` method converts an `Option` into an effectful generator so that it can be used with `yield*` for side effectful code. I also added an `effectMap` function which maps the result of the effectful generator after yielding. This function is just for convenience.