### PR TITLE
💥 Remove `implements`, `Some.fromGenerator` and `NoneException`

### DIFF
--- a/src/exceptions.ts
+++ b/src/exceptions.ts
@@ -23,10 +23,3 @@ export abstract class Exception extends Error {
     });
   }
 }
-
-export class NoneException extends Exception {
-  public constructor() {
-    super();
-    this.setName("NoneException");
-  }
-}

--- a/src/option.ts
+++ b/src/option.ts
@@ -8,9 +8,7 @@ import type { Semigroup } from "./semigroup.js";
 
 export type Option<A> = Some<A> | None;
 
-abstract class OptionTrait
-  implements Semigroup<Option<never>>, TotalOrder<Option<never>>
-{
+abstract class OptionTrait {
   public abstract readonly isSome: boolean;
 
   public abstract readonly isNone: boolean;

--- a/src/option.ts
+++ b/src/option.ts
@@ -1,4 +1,3 @@
-import { NoneException } from "./exceptions.js";
 import type { PartialOrder, Setoid, TotalOrder } from "./order.js";
 import type { Ordering } from "./ordering.js";
 import { Pair } from "./pair.js";
@@ -265,19 +264,6 @@ abstract class OptionTrait {
   public *values<A>(this: Option<A>): Generator<A, void, undefined> {
     if (this.isSome) yield this.value;
   }
-
-  public *effectMap<A, B>(
-    this: Option<A>,
-    morphism: (value: A) => B,
-  ): Generator<Option<A>, B, A> {
-    const value = yield this;
-    return morphism(value);
-  }
-
-  public *effect<A>(this: Option<A>): Generator<Option<A>, A, A> {
-    const value = yield this;
-    return value;
-  }
 }
 
 export class Some<out A> extends OptionTrait {
@@ -306,36 +292,6 @@ export class Some<out A> extends OptionTrait {
     validate: (value: A) => boolean,
   ): Option<A> {
     return validate(value) ? new Some(value) : None.instance;
-  }
-
-  // TODO: <A, B>(getGenerator: () => Generator<Option<A>, B, A>) => Option<B>
-  public static fromGenerator<A>(
-    getGenerator: () => Generator<Option<unknown>, A, unknown>,
-  ): Option<A> {
-    const generator = getGenerator();
-
-    let result: IteratorResult<Option<unknown>, A>;
-
-    try {
-      result = generator.next();
-    } catch (error) {
-      if (error instanceof NoneException) return None.instance;
-      throw error;
-    }
-
-    while (!result.done) {
-      const option = result.value;
-      try {
-        result = option.isSome
-          ? generator.next(option.value)
-          : generator.throw(new NoneException());
-      } catch (error) {
-        if (error instanceof NoneException) return None.instance;
-        throw error;
-      }
-    }
-
-    return new Some(result.value);
   }
 }
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -6,7 +6,7 @@ import { Pair } from "./pair.js";
 
 export type Result<A, E> = Okay<A> | Fail<E>;
 
-abstract class ResultTrait implements TotalOrder<Result<never, never>> {
+abstract class ResultTrait {
   public abstract readonly isOkay: boolean;
 
   public abstract readonly isFail: boolean;

--- a/tests/option.test.ts
+++ b/tests/option.test.ts
@@ -1,16 +1,14 @@
 import { describe, expect, it } from "@jest/globals";
 import fc from "fast-check";
 
-import { NoneException } from "../src/exceptions.js";
 import { id } from "../src/miscellaneous.js";
 import type { Option } from "../src/option.js";
 import { None, Some } from "../src/option.js";
 import { Pair } from "../src/pair.js";
 import type { Result } from "../src/result.js";
-import { Fail, Okay } from "../src/result.js";
 
 import { none, option, pair, result } from "./arbitraries.js";
-import { collatz, hotpo, isPowerOfTwo } from "./utils.js";
+import { collatz } from "./utils.js";
 
 const toStringSome = <A>(a: A): void => {
   try {
@@ -213,95 +211,10 @@ const valuesNone = (m: None): void => {
   expect([...m.values()]).toStrictEqual([]);
 };
 
-const effectMapDefinition = <A, B>(m: Option<A>, f: (a: A) => B): void => {
-  expect(
-    Some.fromGenerator(function* () {
-      const b: B = yield* m.effectMap(f);
-      return b;
-    }),
-  ).toStrictEqual(
-    Some.fromGenerator(function* () {
-      const b: B = f(yield* m.effect());
-      return b;
-    }),
-  );
-};
-
-const effectDefinition = <A>(m: Option<A>): void => {
-  expect(
-    Some.fromGenerator(function* () {
-      const a: A = yield* m.effect();
-      return a;
-    }),
-  ).toStrictEqual(
-    Some.fromGenerator(function* () {
-      const a: A = yield* m.effectMap(id);
-      return a;
-    }),
-  );
-};
-
 const fromValidDefinition = <A>(a: A, f: (a: A) => boolean): void => {
   expect(Some.fromValid(a, f)).toStrictEqual(
     f(a) ? new Some(a) : None.instance,
   );
-};
-
-const fromGeneratorEquivalence = <A, B>(
-  m: Option<A>,
-  p: (a: A) => boolean,
-  f: (a: A) => Option<A>,
-  g: (a: A) => Option<B>,
-): void => {
-  expect(
-    Some.fromGenerator(function* () {
-      let a: A = yield* m.effect();
-      while (!p(a)) a = yield* f(a).effect();
-      const b: B = yield* g(a).effect();
-      return b;
-    }),
-  ).toStrictEqual(
-    m.flatMapUntil((a) => (p(a) ? g(a).map(Okay.of) : f(a).map(Fail.of))),
-  );
-};
-
-const fromGeneratorThrow = <A>(m: Option<A>, n: Option<A>): void => {
-  expect(
-    Some.fromGenerator(function* () {
-      try {
-        const a: A = yield* m.effect();
-        return a;
-      } catch {
-        const a: A = yield* n.effect();
-        return a;
-      }
-    }),
-  ).toStrictEqual(m.or(n));
-};
-
-const fromGeneratorCatch = <A>(m: Option<A>): void => {
-  expect(
-    Some.fromGenerator(function* () {
-      if (m.isSome) throw new NoneException();
-      const a: unknown = yield* m.effect();
-      return a;
-    }),
-  ).toStrictEqual(None.instance);
-};
-
-const fromGeneratorRethrow = <A>(m: Option<A>): void => {
-  expect(() =>
-    Some.fromGenerator(function* () {
-      if (m.isSome) throw new Error("fromGeneratorRethrow");
-
-      try {
-        const a: unknown = yield* m.effect();
-        return a;
-      } catch {
-        throw new Error("fromGeneratorRethrow");
-      }
-    }),
-  ).toThrow(new Error("fromGeneratorRethrow"));
 };
 
 const fromNullishDefinition = <A>(a: A): void => {
@@ -742,28 +655,6 @@ describe("Option", () => {
       fc.assert(fc.property(none, valuesNone));
     });
   });
-
-  describe("effectMap", () => {
-    it("should agree with effect", () => {
-      expect.assertions(100);
-
-      fc.assert(
-        fc.property(
-          option(fc.anything()),
-          fc.func(fc.anything()),
-          effectMapDefinition,
-        ),
-      );
-    });
-  });
-
-  describe("effect", () => {
-    it("should agree with effectMap", () => {
-      expect.assertions(100);
-
-      fc.assert(fc.property(option(fc.anything()), effectDefinition));
-    });
-  });
 });
 
 describe("Some", () => {
@@ -774,46 +665,6 @@ describe("Some", () => {
       fc.assert(
         fc.property(fc.anything(), fc.func(fc.boolean()), fromValidDefinition),
       );
-    });
-  });
-
-  describe("fromGenerator", () => {
-    it("should be equivalent to multiple flatMap calls", () => {
-      expect.assertions(100);
-
-      fc.assert(
-        fc.property(
-          option(fc.integer({ min: 1 })),
-          fc.constant(isPowerOfTwo),
-          fc.constant((n: number): Option<number> => new Some(hotpo(n))),
-          fc.func(option(fc.anything())),
-          fromGeneratorEquivalence,
-        ),
-      );
-    });
-
-    it("should throw a NoneException when the generator yields None", () => {
-      expect.assertions(100);
-
-      fc.assert(
-        fc.property(
-          option(fc.anything()),
-          option(fc.anything()),
-          fromGeneratorThrow,
-        ),
-      );
-    });
-
-    it("should return None when the generator throws a NoneException", () => {
-      expect.assertions(100);
-
-      fc.assert(fc.property(option(fc.anything()), fromGeneratorCatch));
-    });
-
-    it("should re-throw errors that aren't instances of NoneException", () => {
-      expect.assertions(100);
-
-      fc.assert(fc.property(option(fc.anything()), fromGeneratorRethrow));
     });
   });
 });


### PR DESCRIPTION
**♻️ Remove `implements` from `Option` and `Result`**

The `implements` clause was used to ensure that the class implements all the methods of the specified interfaces. However, there's no good reason to do that because if the class doesn't implement the interfaces then the tests would fail. In addition, the `implements` clause is incorrect. The implementation isn't for `Option<never>` and `Result<never, never>`. Hence, it's more accurate to not specify the `implements` clause at all.

**💥 Remove `Some.fromGenerator` and `NoneException`**

I removed `Some.fromGenerator` because it throws a `NoneException` when the generate yields `None`. This is not ideal because `Option` does not implement `MonadError`. Hence, we shouldn't be able to catch the `None` value. If developers want to use generators then they should convert the `Option` into a `Result` and use `Okay.fromGenerator` instead. In doing so, they have to explicitly provide an error. Hence, it's better.
