### PR TITLE
✨ Re-export the `Task` class from `index.ts`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,4 +10,5 @@ export * from "./ordering.js";
 export * from "./pair.js";
 export * from "./result.js";
 export * from "./semigroup.js";
+export * from "./task.js";
 export * from "./text.js";


### PR DESCRIPTION
I forgot to re-export the `Task` class, due to which I couldn't use the `Task` class even after installing the latest version of the library.